### PR TITLE
Refactor `:5e/spellcaster` to be provide-able

### DIFF
--- a/docs/dnd5e/DnD Attrs.md
+++ b/docs/dnd5e/DnD Attrs.md
@@ -4,6 +4,85 @@ D&D 5e-specific `:attrs`
 For different value types, such as that used for `:aoe`, see
 [D&D Value Types](./DnD%20Values.md).
 
+## `:5e/spellcaster`
+
+Add spellcasting ability to the character
+
+### Format
+
+A map of `spellcaster-id -> spellcaster-block` where `spellcaster-block` looks like:
+
+```clojure
+{:cantrips []  ; sequence of level, cantrips gained at that level
+ :slots  ; spellslots table, either a map of class level -> {spell level -> slots}
+         ; or one of the keywords:  :standard, :standard/half
+         ; where the latter is for rangers and paladins. For racial
+         ; spellcasting that only supports cantrips, for example, you
+         ; can provide :none if no slots are allowed
+ :multiclass-levels-mod 2  ; number by which to devide class level when
+                           ; determining multiclass spellcaster level.
+                           ; Default is just 1; rangers/paladins are 2
+ :slots-type :id  ; if non-standard (like Warlock) this should be a
+                  ; namespace-less keyword
+ :slots-label "Label"  ; if :slots-type is provided, this should also
+                       ; be provided
+ :restore-trigger :long-rest  ; :long-rest is the default
+ :ability :wis  ; base ability for spellcasting modifier
+ :acquires? false  ; whether the class acquires spells before preparing them. This is
+                   ; sort of a special case for Wizards. If True, the :spells list
+                   ; is used to select :acquired spells, and, if the class :prepares?
+                   ; then it instead prepares from the :acquired-spells list (it is
+                   ; sort of assumed that if a class acquires they also prepare, but
+                   ; you should set the flag anyway).
+                   ; Futhermore, for an :acquires? spellcaster, cantrips, once known,
+                   ; are always prepared.
+ :prepares? true  ; Whether the class prepares spells or just knows them
+ :known [table]  ; Vector that determines how many spells can be known or prepared
+                 ; at a given level (where the first index in the table is level 1).
+                 ; If not provided, :slots MUST be either :standard or :standard/half.
+                 ; Bard and Ranger in particular use a standard spellslot table, but
+                 ; have a distinct table of known spells. If NO spells are known at a
+                 ; level (such as for the Arcane Trickster) 0 can be used.
+
+ :spells :<class>/spells  ; id of a feature whose selected options provide available
+                          ; spells (or known spells for an :acquires? spellcaster)
+ :extra-spells :<class>/extra-spells  ; id of a list of spells that are always
+                                      ; available, such as a cleric's domain spells.
+ :acquired-label "Spellbook"  ; label for the :acquired-spells list
+ :acquires?-spells :<class>/acquires  ; id of a feature whose selected options provide
+                                      ; available spells for an :acquires? spellcaster.
+ }
+```
+
+EX:
+
+```clojure
+  {:5e/spellcaster
+   {:paladin
+    {:ability :cha
+     :spells :paladin/spells-list
+     :slots :standard/half
+     :extra-spells :paladin/extra-spells
+     :multiclass-levels-mod 2
+     :prepares? true}}}
+
+; NOTE: this would make the character have spells exactly as if
+; they were a wizard, without actually having the class
+[:!provide-attr
+ [:5e/spellcaster :my-wizard]
+ {:cantrips [1 3,
+             4 1,
+             10 1]
+  :ability :int
+  :spells :wizard/spells-list
+  :extra-spells :wizard/extra-spells
+  :acquires?-spells :wizard/prepared-spells
+  :acquired-label "Spellbook"
+  :prepares? true
+  :acquires? true
+  }]
+```
+
 ## `:action`
 
 Declare that a feature can be used as an Action.

--- a/resources/sources/dnd5e/classes/bard.edn
+++ b/resources/sources/dnd5e/classes/bard.edn
@@ -3,15 +3,16 @@
   :name "Bard"
   :attrs
   {:5e/spellcaster
-   {:cantrips [1 2,
-               4 1,
-               10 1]
-    :known [4 5 6 7 8 9 10 11 12 14 15 15 16 18 19 19 20 22 22 22]
-    :ability :cha
-    :spells :bard/spells-list
-    :extra-spells :bard/extra-spells
-    :prepares? false
-    }
+   {:bard
+    {:cantrips [1 2,
+                4 1,
+                10 1]
+     :known [4 5 6 7 8 9 10 11 12 14 15 15 16 18 19 19 20 22 22 22]
+     :ability :cha
+     :spells :bard/spells-list
+     :extra-spells :bard/extra-spells
+     :prepares? false
+     }}
 
    :5e/starting-eq
    [(:rapier :longsword {:type :weapon

--- a/resources/sources/dnd5e/classes/cleric.edn
+++ b/resources/sources/dnd5e/classes/cleric.edn
@@ -3,13 +3,14 @@
   :name "Cleric"
   :attrs
   {:5e/spellcaster
-   {:cantrips [1 3,
-               4 1,
-               10 1]
-    :ability :wis
-    :spells :cleric/spells-list
-    :extra-spells :cleric/extra-spells
-    :prepares? true}
+   {:cleric
+    {:cantrips [1 3,
+                4 1,
+                10 1]
+     :ability :wis
+     :spells :cleric/spells-list
+     :extra-spells :cleric/extra-spells
+     :prepares? true}}
 
    :5e/starting-eq
    [(:mace :warhammer)

--- a/resources/sources/dnd5e/classes/druid.edn
+++ b/resources/sources/dnd5e/classes/druid.edn
@@ -3,13 +3,14 @@
   :name "Druid"
   :attrs
   {:5e/spellcaster
-   {:cantrips [1 2,
-               4 1,
-               10 1]
-    :ability :wis
-    :spells :druid/spells-list
-    :extra-spells :druid/extra-spells
-    :prepares? true}
+   {:druid
+    {:cantrips [1 2,
+                4 1,
+                10 1]
+     :ability :wis
+     :spells :druid/spells-list
+     :extra-spells :druid/extra-spells
+     :prepares? true}}
 
    :5e/starting-eq
    [(:shield {:type :weapon

--- a/resources/sources/dnd5e/classes/paladin.edn
+++ b/resources/sources/dnd5e/classes/paladin.edn
@@ -3,12 +3,13 @@
   :name "Paladin"
   :attrs
   {:5e/spellcaster
-   {:ability :cha
-    :spells :paladin/spells-list
-    :slots :standard/half
-    :extra-spells :paladin/extra-spells
-    :multiclass-levels-mod 2
-    :prepares? true}
+   {:paladin
+    {:ability :cha
+     :spells :paladin/spells-list
+     :slots :standard/half
+     :extra-spells :paladin/extra-spells
+     :multiclass-levels-mod 2
+     :prepares? true}}
 
    :5e/starting-eq
    [; shield + weapon or 2 weapons

--- a/resources/sources/dnd5e/classes/ranger.edn
+++ b/resources/sources/dnd5e/classes/ranger.edn
@@ -3,13 +3,14 @@
   :name "Ranger"
   :attrs
   {:5e/spellcaster
-   {:ability :wis
-    :known [0 2 3 3 4 4 5 5 6 6 7 7 8 8 9 9 10 10 11 11]
-    :spells :ranger/spells-list
-    :slots :standard/half
-    :extra-spells :ranger/extra-spells
-    :multiclass-levels-mod 2
-    :prepares? false}
+   {:ranger
+    {:ability :wis
+     :known [0 2 3 3 4 4 5 5 6 6 7 7 8 8 9 9 10 10 11 11]
+     :spells :ranger/spells-list
+     :slots :standard/half
+     :extra-spells :ranger/extra-spells
+     :multiclass-levels-mod 2
+     :prepares? false}}
 
    :5e/starting-eq
    [(:scale-mail :leather-armor)

--- a/resources/sources/dnd5e/classes/sorcerer.edn
+++ b/resources/sources/dnd5e/classes/sorcerer.edn
@@ -3,15 +3,16 @@
   :name "Sorcerer"
   :attrs
   {:5e/spellcaster
-   {:cantrips [1 4,
-               4 1,
-               10 1]
-    :known [2 3 4 5 6 7 8 9 10 11 12 12 13 13 14 14 15 15 15 15]
-    :ability :cha
-    :spells :sorcerer/spells-list
-    :extra-spells :sorcerer/extra-spells
-    :prepares? false
-    }
+   {:sorcerer
+    {:cantrips [1 4,
+                4 1,
+                10 1]
+     :known [2 3 4 5 6 7 8 9 10 11 12 12 13 13 14 14 15 15 15 15]
+     :ability :cha
+     :spells :sorcerer/spells-list
+     :extra-spells :sorcerer/extra-spells
+     :prepares? false
+     }}
 
    :5e/starting-eq
    [([:light-crossbow :crossbow-bolt] {:type :weapon

--- a/resources/sources/dnd5e/classes/warlock.edn
+++ b/resources/sources/dnd5e/classes/warlock.edn
@@ -4,30 +4,31 @@
 
   :attrs
   {:5e/spellcaster
-   {:cantrips [1 2,
-               4 1,
-               10 1]
-    :known [2 3 4 5 6 7 8 9 10 11 12 12 13 13 14 14 15 15 15 15]
-    :ability :cha
-    :spells :warlock/spells-list
-    :extra-spells :warlock/extra-spells
-    :prepares? false
+   {:warlock
+    {:cantrips [1 2,
+                4 1,
+                10 1]
+     :known [2 3 4 5 6 7 8 9 10 11 12 12 13 13 14 14 15 15 15 15]
+     :ability :cha
+     :spells :warlock/spells-list
+     :extra-spells :warlock/extra-spells
+     :prepares? false
 
-    :slots-type :pact-magic
-    :slots-label "Pact Magic"
-    :slots {1 {1 1}, 2 {1 2}
-            3 {2 2}, 4 {2 2}
-            5 {3 2}, 6 {3 2}
-            7 {4 2}, 8 {4 2}
-            9 {5 2}, 10 {5 2}
-            11 {5 3}, 12 {5 3}
-            13 {5 3}, 14 {5 3}
-            15 {5 3}, 16 {5 3}
-            17 {5 4}, 18 {5 4}
-            19 {5 4}, 20 {5 4}}
-    :multiclass-levels-mod 0
-    :restore-trigger :short-rest
-    }
+     :slots-type :pact-magic
+     :slots-label "Pact Magic"
+     :slots {1 {1 1}, 2 {1 2}
+             3 {2 2}, 4 {2 2}
+             5 {3 2}, 6 {3 2}
+             7 {4 2}, 8 {4 2}
+             9 {5 2}, 10 {5 2}
+             11 {5 3}, 12 {5 3}
+             13 {5 3}, 14 {5 3}
+             15 {5 3}, 16 {5 3}
+             17 {5 4}, 18 {5 4}
+             19 {5 4}, 20 {5 4}}
+     :multiclass-levels-mod 0
+     :restore-trigger :short-rest
+     }}
 
    :5e/starting-eq
    [([:light-crossbow :crossbow-bolt] {:type :weapon

--- a/resources/sources/dnd5e/classes/wizard.edn
+++ b/resources/sources/dnd5e/classes/wizard.edn
@@ -3,17 +3,18 @@
   :name "Wizard"
   :attrs
   {:5e/spellcaster
-   {:cantrips [1 3,
-               4 1,
-               10 1]
-    :ability :int
-    :spells :wizard/spells-list
-    :extra-spells :wizard/extra-spells
-    :acquires?-spells :wizard/prepared-spells
-    :acquired-label "Spellbook"
-    :prepares? true
-    :acquires? true
-    }
+   {:wizard
+    {:cantrips [1 3,
+                4 1,
+                10 1]
+     :ability :int
+     :spells :wizard/spells-list
+     :extra-spells :wizard/extra-spells
+     :acquires?-spells :wizard/prepared-spells
+     :acquired-label "Spellbook"
+     :prepares? true
+     :acquires? true
+     }}
 
    :5e/starting-eq
    [(:quarterstaff :dagger)

--- a/resources/sources/dnd5e/races/elf.edn
+++ b/resources/sources/dnd5e/races/elf.edn
@@ -33,10 +33,11 @@
   {:5e/&ability-score-increase
    {:int 1}
    :5e/spellcaster
-   {:cantrips [0 1]
-    :slots :none
-    :ability :int
-    :spells :wizard/spells-list}}
+   {:elf
+    {:cantrips [0 1]
+     :slots :none
+     :ability :int
+     :spells :wizard/spells-list}}}
 
   :+features
   [{:id :high-elf/cantrip

--- a/resources/sources/dnd5e/races/tiefling.edn
+++ b/resources/sources/dnd5e/races/tiefling.edn
@@ -9,9 +9,10 @@
    :5e/speed 30
 
    :5e/spellcaster
-   {:slots :none
-    :ability :cha
-    :extra-spells :tiefling/extra-spells}}
+   {:tiefling
+    {:slots :none
+     :ability :cha
+     :extra-spells :tiefling/extra-spells}}}
 
   :features
   [:background

--- a/src/cljs/wish/sheets/dnd5e.cljs
+++ b/src/cljs/wish/sheets/dnd5e.cljs
@@ -636,7 +636,7 @@
      ^{:key (:id s)}
      [spell-block s])])
 
-(defn spells-section [spell-classes]
+(defn spells-section [spellcasters]
   (let [slots-sets (<sub [::subs/spell-slots])
         slots-used (<sub [::subs/spell-slots-used])
         prepared-spells-by-class (<sub [::subs/prepared-spells-by-class])]
@@ -653,33 +653,32 @@
            [spell-slot-use-block
             id level total (get-in slots-used [id level])]])])
 
-     (for [c spell-classes]
-       (let [prepared-spells (get prepared-spells-by-class (:id c))
-             attrs (-> c :attrs :5e/spellcaster)
-             prepares? (:prepares? attrs)
-             acquires? (:acquires? attrs)
-             fixed-list? (not (:spells attrs))
+     (for [s spellcasters]
+       (let [prepared-spells (get prepared-spells-by-class (:id s))
+             prepares? (:prepares? s)
+             acquires? (:acquires? s)
+             fixed-list? (not (:spells s))
              any-prepared? (> (count prepared-spells) 0)
              prepared-label (if prepares?
                               "prepared"
                               "known")]
-         ^{:key (:id c)}
+         ^{:key (:id s)}
          [:div.spells
-          [:h4 (:name c)
+          [:h4 (:name s)
            (when-not fixed-list?
              [:div.manage-link
               [link>evt [:toggle-overlay
-                         [#'overlays/spell-management c]
+                         [#'overlays/spell-management s]
                          :scrollable? true]
                (str "Manage " prepared-label " spells")]])
            (when acquires?
              [:div.manage-link
               [link>evt [:toggle-overlay
                          [#'overlays/spell-management
-                          c
+                          s
                           :mode :acquisition]
                          :scrollable? true]
-               (str "Manage " (:acquired-label attrs))]])]
+               (str "Manage " (:acquired-label s))]])]
 
           (when-not fixed-list?
             [:div.list-info (str (str/capitalize prepared-label) " Spells")
@@ -851,7 +850,7 @@
    [proficiencies-section]])
 
 (defn- sheet-right-page []
-  (let [spell-classes (seq (<sub [::subs/spellcaster-classes]))
+  (let [spellcasters (seq (<sub [::subs/spellcaster-blocks]))
         smartphone? (= :smartphone (<sub [:device-type]))
         page (<sub [::subs/page])]
     [:<>
@@ -859,7 +858,7 @@
       (when smartphone?
         [nav-link page :abilities "Abilities"])
       [nav-link page :actions "Actions"]
-      (when spell-classes
+      (when spellcasters
         [nav-link page :spells "Spells"])
       [nav-link page :inventory "Inventory"]
       [nav-link page :features "Features"]]
@@ -879,10 +878,10 @@
                      styles/actions-section
                      [actions-section])
 
-       (when spell-classes
+       (when spellcasters
          (main-section page :spells
                        styles/spells-section
-                       [spells-section spell-classes]))
+                       [spells-section spellcasters]))
 
        (main-section page :inventory
                      styles/inventory-section

--- a/src/cljs/wish/sheets/dnd5e/overlays.cljs
+++ b/src/cljs/wish/sheets/dnd5e/overlays.cljs
@@ -531,12 +531,11 @@
          [spell-card s])])))
 
 (defn spell-management
-  [the-class & {:keys [mode]
-                :or {mode :default}}]
-  (let [attrs (-> the-class :attrs :5e/spellcaster)
-        {:keys [acquires? prepares?]} attrs
+  [spellcaster & {:keys [mode]
+                  :or {mode :default}}]
+  (let [{:keys [acquires? prepares?]} spellcaster
 
-        knowable (<sub [::subs/knowable-spell-counts (:id the-class)])
+        knowable (<sub [::subs/knowable-spell-counts (:id spellcaster)])
 
         ; in :acquisition mode (eg: for spellbooks), cantrips have
         ; the normal limit but spells are unlimited
@@ -552,15 +551,15 @@
 
         title (case mode
                 :default (str "Manage "
-                              (:name the-class)
+                              (:name spellcaster)
                               (if prepares?
                                 " Prepared"
                                 " Known")
                               " Spells")
                 :acquisition (str "Manage "
-                                  (:name the-class)
+                                  (:name spellcaster)
                                   " "
-                                  (:acquired-label attrs)))
+                                  (:acquired-label spellcaster)))
 
         spells-limit (:spells limits)
         cantrips-limit (when-not (and acquires?
@@ -573,21 +572,22 @@
                          ; for an :acquires? spellcaster in default mode,
                          ; the source for their prepared spells is their
                          ; :acquires?-spells list
-                         (:acquires?-spells attrs)
+                         (:acquires?-spells spellcaster)
 
                          ; otherwise, it's the :spells list
-                         (:spells attrs))
+                         (:spells spellcaster))
 
-        all-prepared (<sub [::subs/my-prepared-spells-by-type (:id the-class)])
+        all-prepared (<sub [::subs/my-prepared-spells-by-type (:id spellcaster)])
         prepared-spells-count (count (:spells all-prepared))
         prepared-cantrips-count (count (:cantrips all-prepared))
 
-        spells (<sub [::subs/preparable-spell-list the-class available-list])
+        spells (<sub [::subs/preparable-spell-list spellcaster available-list])
+        _ (println (count spells) available-list)
 
         can-select-spells? (or (nil? spells-limit)
                                (< prepared-spells-count spells-limit))
         can-select-cantrips? (< prepared-cantrips-count cantrips-limit)
-        spell-opts (assoc attrs
+        spell-opts (assoc spellcaster
                           :verb prepare-verb
                           :source-list available-list
                           :selectable? (fn [{:keys [spell-level]}]

--- a/src/cljs/wish/sheets/dnd5e/overlays.cljs
+++ b/src/cljs/wish/sheets/dnd5e/overlays.cljs
@@ -582,7 +582,6 @@
         prepared-cantrips-count (count (:cantrips all-prepared))
 
         spells (<sub [::subs/preparable-spell-list spellcaster available-list])
-        _ (println (count spells) available-list)
 
         can-select-spells? (or (nil? spells-limit)
                                (< prepared-spells-count spells-limit))

--- a/test/cljs/wish/sheets/dnd5e/subs_test.cljs
+++ b/test/cljs/wish/sheets/dnd5e/subs_test.cljs
@@ -19,31 +19,34 @@
 (def ^:private warlock
   {:attrs
    {:5e/spellcaster
-    {:cantrips [1 3,
-                4 1,
-                10 1]
-     :ability :cha
-     :spells :warlock/spells-list
-     :extra-spells :warlock/extra-spells
-     :prepares? false
+    {:warlock
+     {:cantrips [1 3,
+                 4 1,
+                 10 1]
+      :ability :cha
+      :spells :warlock/spells-list
+      :extra-spells :warlock/extra-spells
+      :prepares? false
 
-     :slots-type :pact-magic
-     :slots-label "Pact Magic"
-     :slots {1 {1 1}, 2 {1 2}
-             3 {2 2}, 4 {2 2}
-             5 {3 2}, 6 {3 2}
-             7 {4 2}, 8 {4 2}
-             9 {5 2}, 10 {5 2}
-             11 {5 3}, 12 {5 3}
-             13 {5 3}, 14 {5 3}
-             15 {5 3}, 16 {5 3}
-             17 {5 4}, 18 {5 4}
-             19 {5 4}, 20 {5 4}}
-     :known [2 3 4 5 6 7 8 9 10 11 12 12 13 13 14 14 15 15 15 15]
-     :multiclass-levels-mod 0
-     :restore-trigger :short-rest
-     }
+      :slots-type :pact-magic
+      :slots-label "Pact Magic"
+      :slots {1 {1 1}, 2 {1 2}
+              3 {2 2}, 4 {2 2}
+              5 {3 2}, 6 {3 2}
+              7 {4 2}, 8 {4 2}
+              9 {5 2}, 10 {5 2}
+              11 {5 3}, 12 {5 3}
+              13 {5 3}, 14 {5 3}
+              15 {5 3}, 16 {5 3}
+              17 {5 4}, 18 {5 4}
+              19 {5 4}, 20 {5 4}}
+      :known [2 3 4 5 6 7 8 9 10 11 12 12 13 13 14 14 15 15 15 15]
+      :multiclass-levels-mod 0
+      :restore-trigger :short-rest
+      }}
     }})
+
+(def warlock-caster (-> warlock :attrs :5e/spellcaster :warlock))
 
 (deftest level->proficiency-bonus-test
   (testing "Low levels"
@@ -65,20 +68,18 @@
     (is (= {:spells 4
             :cantrips 3}
            (knowable-spell-counts-for
-             (assoc warlock :level 3)
+             (assoc warlock-caster :level 3)
              {})))
     (is (= {:spells 11
             :cantrips 5}
            (knowable-spell-counts-for
-             (assoc warlock :level 10)
+             (assoc warlock-caster :level 10)
              {})))
     (is (= 0
            (:spells
              (knowable-spell-counts-for
                {:level 2
-                :attrs
-                {:5e/spellcaster
-                 {:known [0 0 3]}}}
+                :known [0 0 3]}
                {})))))
 
   (testing "Standard (eg: cleric)"
@@ -87,12 +88,10 @@
            (knowable-spell-counts-for
              {:level 7
               :id :cleric
-              :attrs
-              {:5e/spellcaster
-               {:slots :standard
-                :cantrips [1 3,
-                           4 1,
-                           10 1]}}}
+              :slots :standard
+              :cantrips [1 3,
+                         4 1,
+                         10 1]}
              {:cleric 3})))
 
     ; NOTE: :slots is omitted here; :standard is the default!
@@ -101,11 +100,9 @@
            (knowable-spell-counts-for
              {:level 7
               :id :cleric
-              :attrs
-              {:5e/spellcaster
-               {:cantrips [1 3,
-                           4 1,
-                           10 1]}}}
+              :cantrips [1 3,
+                         4 1,
+                         10 1]}
              {:cleric 3})))))
 
 (deftest spell-slots-test
@@ -115,15 +112,13 @@
   (testing "Single class, half"
     (is (= (->standard {1 4, 2 3})
            (spell-slots [{:level 7
-                          :attrs
-                          {:5e/spellcaster
-                           {:slots :standard/half}}}]))))
+                          :slots :standard/half}]))))
   (testing "Single class, Warlock-like"
     (is (= {:pact-magic
             {:label "Pact Magic"
              :slots {4 2}}}
            (spell-slots [(merge
-                           warlock
+                           warlock-caster
                            {:level 7})]))))
 
   (testing "Multiclass, both standard"
@@ -134,10 +129,8 @@
     (is (= (->standard {1 4, 2 3, 3 3, 4 3, 5 2})
            (spell-slots [{:level 7}
                          {:level 7
-                          :attrs
-                          {:5e/spellcaster
-                           {:slots :standard/half
-                            :multiclass-levels-mod 2}}}]))))
+                          :slots :standard/half
+                          :multiclass-levels-mod 2}]))))
   (testing "Multiclass, one warlock-like"
     (is (= (assoc (->standard {1 4, 2 3, 3 3, 4 1})
                   :pact-magic
@@ -145,7 +138,7 @@
                    :slots {4 2}})
            (spell-slots [{:level 7}
                          (merge
-                           warlock
+                           warlock-caster
                            {:level 7})])))))
 
 (deftest calculate-weapon-test


### PR DESCRIPTION
This refactor makes it easier to add :5e/spellcaster instances.

Before, :5e/spellcaster was a singleton map per entity (IE: one
per class or race). This works in general, but makes implementing
things like the Warlock's Book of Ancient Secrets, which effectively
grants you an `:acquires?` spellcaster "class," or the "Magic Initiate"
feat, which also grants you a separate spellcaster "class," difficult
or impossible to implement, since the obvious solution of using
`[:!provide-attr :5e/spellcaster]` would overwrite any existing
spellcasting on your race or class.

By making :5e/spellcaster into a *map* of spellcaster "blocks," we
can easily use `:!provide-attr` without fear of overwrites! This is
a big breaking change, so hopefully nobody has been using WISH
secretly and making a bunch of custom spellcasters....