### PR TITLE
Improve feature sorting for builder rendering

### DIFF
--- a/resources/sources/dnd5e/0-common/common-features.edn
+++ b/resources/sources/dnd5e/0-common/common-features.edn
@@ -53,7 +53,7 @@
   :name "Ability Score Improvement (or Feat)"
   :desc "You can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can’t increase an ability score above 20 using this feature.
 
-Alternatively, if your DM uses the optional Feats rule, you can choose a Feat."
+Alternatively, using the optional feats rule, you can forgo increasing any ability scores to take a feat of your choice instead. A feat represents a talent or an area of expertise that gives a character special capabilities. It embodies training, experience, and abilities beyond what a class provides. You can take each feat only once, unless the feat’s description says otherwise."
   :implicit? true
   :instanced? true
   :max-options 1
@@ -66,9 +66,10 @@ Alternatively, if your DM uses the optional Feats rule, you can choose a Feat."
   }
 
  {:id :feats
-  :name "Feats"
+  :name "Extra Feats"
   :desc "A feat represents a talent or an area of expertise that gives a character special capabilities. It embodies training, experience, and abilities beyond what a class provides.
-At certain levels, your class gives you the Ability Score Improvement feature. Using the optional feats rule, you can forgo taking that feature to take a feat of your choice instead. You can take each feat only once, unless the feat’s description says otherwise."
+
+You can normally only take feats in place of Ability Score Improvements, but with permission from your DM you may add extra feats here."
   :primary-only? true
   :max-options 99
   :values [:all-feats]}

--- a/resources/sources/dnd5e/0-common/common-features.edn
+++ b/resources/sources/dnd5e/0-common/common-features.edn
@@ -41,6 +41,30 @@
     :name "Charisma"
     :! [[:!update-attr [:buffs :cha] inc]]}] }
 
+ {:id :feat
+  :name "Feat"
+  :desc "A feat represents a talent or an area of expertise that gives a character special capabilities. It embodies training, experience, and abilities beyond what a class provides."
+  :instanced? true
+  :max-options 1
+  :values [:all-feats]
+  }
+
+ {:id :abi-or-feat
+  :name "Ability Score Improvement (or Feat)"
+  :desc "You can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can’t increase an ability score above 20 using this feature.
+
+Alternatively, if your DM uses the optional Feats rule, you can choose a Feat."
+  :implicit? true
+  :instanced? true
+  :max-options 1
+  :values [{:id :provide/abi
+            :name "Ability Score Improvement"
+            :! [[:!provide-feature :ability-improvement]]}
+           {:id :provide/feat
+            :name "Feat"
+            :! [[:!provide-feature :feat]]}]
+  }
+
  {:id :feats
   :name "Feats"
   :desc "A feat represents a talent or an area of expertise that gives a character special capabilities. It embodies training, experience, and abilities beyond what a class provides.

--- a/resources/sources/dnd5e/0-common/common-features.edn
+++ b/resources/sources/dnd5e/0-common/common-features.edn
@@ -57,10 +57,10 @@ Alternatively, using the optional feats rule, you can forgo increasing any abili
   :implicit? true
   :instanced? true
   :max-options 1
-  :values [{:id :provide/abi
+  :values [{:id :abi-or-feat/abi
             :name "Ability Score Improvement"
             :! [[:!provide-feature :ability-improvement]]}
-           {:id :provide/feat
+           {:id :abi-or-feat/feat
             :name "Feat"
             :! [[:!provide-feature :feat]]}]
   }

--- a/resources/sources/dnd5e/classes/barbarian.edn
+++ b/resources/sources/dnd5e/classes/barbarian.edn
@@ -105,7 +105,7 @@ You have advantage on Dexterity saving throws against effects that you can see, 
                 ]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             5 {:+features
                [:extra-attack
@@ -126,7 +126,7 @@ You have advantage on Dexterity saving throws against effects that you can see, 
 Additionally, if you are surprised at the beginning of combat and aren’t incapacitated, you can act normally on your first turn, but only if you enter your rage before doing anything else on that turn."}]}
 
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             9 {:+features
                [{:id :barbarian/brutal-critical
@@ -143,7 +143,7 @@ Each time you use this feature after the first, the DC increases by 5. When you 
                   }]}
 
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             15 {:+features
                 [{:id :barbarian/persistent-rage
@@ -151,7 +151,7 @@ Each time you use this feature after the first, the DC increases by 5. When you 
                   :desc "Beginning at 15th level, your rage is so fierce that it ends early only if you fall unconscious or if you choose to end it."}]}
 
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             18 {:+features
                 [{:id :barbarian/indomitable-might
@@ -159,7 +159,7 @@ Each time you use this feature after the first, the DC increases by 5. When you 
                   :desc "If your total for a Strength check is less than your Strength score, you can use that score in place of the total."}]}
 
             19 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             20 {:+feature
                 [{:id :barbarian/primal-champion

--- a/resources/sources/dnd5e/classes/bard.edn
+++ b/resources/sources/dnd5e/classes/bard.edn
@@ -114,7 +114,7 @@ The extra hit points increase when you reach certain levels in this class: to 1d
                 :bard/expertise]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             5 {:+features
                [{:id :bard/font-of-inspiration
@@ -130,7 +130,7 @@ The extra hit points increase when you reach certain levels in this class: to 1d
                       true]]}]}
 
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             10 {:+features
                 [:bard/expertise
@@ -158,11 +158,11 @@ You learn two additional spells from any class at 14th level and again at 18th l
                  ]}
 
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             19 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             20 {:+features
                 [{:id :bard/superior-inspiration

--- a/resources/sources/dnd5e/classes/cleric.edn
+++ b/resources/sources/dnd5e/classes/cleric.edn
@@ -70,7 +70,7 @@ A turned creature must spend its turns trying to move as far away from you as it
                       true]]}]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             5 {:+features
                [{:id :cleric/destroy-undead
@@ -94,7 +94,7 @@ A turned creature must spend its turns trying to move as far away from you as it
                  }]}
 
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             10 {:+features
                 [{:id :cleric/divine-intervention
@@ -113,11 +113,11 @@ At 20th level, your call for intervention succeeds automatically, no roll requir
                        true]]}]}
 
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             19 {:+features
-                [:ability-improvement]}}}]
+                [:abi-or-feat]}}}]
 
 [:!provide-feature
  {:id :cleric/channel-divinity

--- a/resources/sources/dnd5e/classes/druid.edn
+++ b/resources/sources/dnd5e/classes/druid.edn
@@ -100,13 +100,13 @@
                  :max-options 1}]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             18 {:+features
                 [{:id :druid/timeless-body
@@ -117,7 +117,7 @@
                   :desc "Beginning at 18th level, you can cast many of your druid spells in any shape you assume using Wild Shape. You can perform the somatic and verbal components of a druid spell while in a beast shape, but you aren’t able to provide material components."}]}
 
             19 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             20 {:+features
                 [{:id :druid/arch
                   :name "Archdruid"

--- a/resources/sources/dnd5e/classes/fighter.edn
+++ b/resources/sources/dnd5e/classes/fighter.edn
@@ -94,7 +94,7 @@ Once you use this feature, you must finish a short or long rest before you can u
                 ]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             5 {:+features
                [{:id :fighter/extra-attack
@@ -111,10 +111,10 @@ The number of attacks increases to three when you reach 11th level in this class
                 ]}
 
             6 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             9 {:+features
                [{:id :fighter/indomitable
@@ -132,16 +132,16 @@ You can use this feature twice between long rests starting at 13th level and thr
                        :restore-trigger :long-rest}]]}]}
 
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             14 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             19 {:+features
-                [:ability-improvement]} }}]
+                [:abi-or-feat]} }}]
 
 [:!provide-options
  :fighter/archetype

--- a/resources/sources/dnd5e/classes/monk.edn
+++ b/resources/sources/dnd5e/classes/monk.edn
@@ -161,7 +161,7 @@ If you reduce the damage to 0, you can catch the missile if it is small enough f
                       true]]}]}
 
             4 {:+features
-               [:ability-improvement
+               [:abi-or-feat
 
                 {:id :monk/slow-fall
                  :name "Slow Fall"
@@ -196,7 +196,7 @@ If you reduce the damage to 0, you can catch the missile if it is small enough f
                       true]]}]}
 
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             10 {:+features
                 [{:id :monk/purity-body
@@ -207,7 +207,7 @@ If you reduce the damage to 0, you can catch the missile if it is small enough f
                        {:desc "You are immune to disease and poison."}]]}]}
 
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             13 {:+features
                 [{:id :monk/tongue-sun-moon
@@ -234,7 +234,7 @@ Additionally, whenever you make a saving throw and fail, you can spend 1 ki poin
                   :name "Timeless Body"
                   :desc "At 15th level, your ki sustains you so that you suffer none of the frailty of old age, and you can’t be aged magically. You can still die of old age, however. In addition, you no longer need food or water."}]}
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             18 {:+features
                 [{:id :monk/empty-body
@@ -247,7 +247,7 @@ Additionally, you can spend 8 ki points to cast the astral projection spell, wit
                        true]]}]}
 
             19 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             20 {:+features
                 [{:id :monk/perfect-self

--- a/resources/sources/dnd5e/classes/paladin.edn
+++ b/resources/sources/dnd5e/classes/paladin.edn
@@ -124,7 +124,7 @@ Your choice grants you features at 3rd level and again at 7th, 15th, and 20th le
                  :max-options 1}]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
             5 {:+features
                [:extra-attack]}
 
@@ -135,7 +135,7 @@ Your choice grants you features at 3rd level and again at 7th, 15th, and 20th le
 At 18th level, the range of this aura increases to 30 feet."}]}
 
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             10 {:+features
                 [{:id :paladin/aura-courage
@@ -153,7 +153,7 @@ At 18th level, the range of this aura increases to 30 feet."}]}
                         :type :radiant}]]}]}
 
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             14 {:+features
                 [{:id :paladin/cleansing-touch
@@ -172,9 +172,9 @@ You can use this feature a number of times equal to your Charisma modifier (a mi
                        true]]}]}
 
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             19 {:+features
-                [:ability-improvement]}}}]
+                [:abi-or-feat]}}}]
 
 [:!provide-options
  :paladin/oath

--- a/resources/sources/dnd5e/classes/ranger.edn
+++ b/resources/sources/dnd5e/classes/ranger.edn
@@ -189,13 +189,13 @@ You choose additional favored terrain types at 6th and 10th level."
                 ]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             5 {:+features
                [:extra-attack]}
 
             8 {:+features
-               [:ability-improvement
+               [:abi-or-feat
 
                 {:id :ranger/lands-stride
                  :name "Land's Stride"
@@ -209,7 +209,7 @@ In addition, you have advantage on saving throws against plants that are magical
 Once you are camouflaged in this way, you can try to hide by pressing yourself up against a solid surface, such as a tree or wall, that is at least as tall and wide as you are. You gain a +10 bonus to Dexterity (Stealth) checks as long as you remain there without moving or taking actions. Once you move or take an action or a reaction, you must camouflage yourself again to gain this benefit."}]}
 
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             14 {:+features
                 [{:id :ranger/vanish
@@ -220,7 +220,7 @@ Once you are camouflaged in this way, you can try to hide by pressing yourself u
                        true]]}]}
 
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             18 {:+features
                 [{:id :ranger/feral-senses
@@ -229,7 +229,7 @@ Once you are camouflaged in this way, you can try to hide by pressing yourself u
 You are also aware of the location of any invisible creature within 30 feet of you, provided that the creature isn’t hidden from you and you aren’t blinded or deafened."}]}
 
             19 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             20 {:+features
                 [{:id :ranger/foe-slayer

--- a/resources/sources/dnd5e/classes/rogue.edn
+++ b/resources/sources/dnd5e/classes/rogue.edn
@@ -147,7 +147,7 @@ In addition, you understand a set of secret signs and symbols used to convey sho
                   :desc "By 11th level, you have refined your chosen skills until they approach perfection. Whenever you make an ability check that lets you add your proficiency bonus, you can treat a d20 roll of 9 or lower as a 10."}]}
 
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             14 {:+features
                 [{:id :rogue/blindsense
@@ -162,7 +162,7 @@ In addition, you understand a set of secret signs and symbols used to convey sho
                  :save-proficiency/wis]}
 
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             18 {:+features
                 [{:id :rogue/elusive
@@ -170,7 +170,7 @@ In addition, you understand a set of secret signs and symbols used to convey sho
                   :desc "Beginning at 18th level, you are so evasive that attackers rarely gain the upper hand against you. No attack roll has advantage against you while you aren’t incapacitated."}]}
 
             19 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             20 {:+features
                 [{:id :rogue/stroke-luck

--- a/resources/sources/dnd5e/classes/rogue.edn
+++ b/resources/sources/dnd5e/classes/rogue.edn
@@ -118,7 +118,7 @@ In addition, you understand a set of secret signs and symbols used to convey sho
                 ]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             5 {:+features
                [{:id :rogue/uncanny-dodge
@@ -136,10 +136,10 @@ In addition, you understand a set of secret signs and symbols used to convey sho
                 ]}
 
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             10 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             11 {:+features
                 [{:id :rogue/reliable-talent

--- a/resources/sources/dnd5e/classes/sorcerer.edn
+++ b/resources/sources/dnd5e/classes/sorcerer.edn
@@ -93,15 +93,15 @@ You can use only one Metamagic option on a spell when you cast it, unless otherw
                                   :else 4))}]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             19 {:+features
-                [:ability-improvement]}}
+                [:abi-or-feat]}}
   }]
 
 ;;

--- a/resources/sources/dnd5e/classes/warlock.edn
+++ b/resources/sources/dnd5e/classes/warlock.edn
@@ -100,9 +100,9 @@ Additionally, when you gain a level in this class, you can choose one of the inv
                  :max-options 1}]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
 
             11 {:+features
                 [{:id :warlock/mystic-arcanum
@@ -122,7 +122,7 @@ At higher levels, you gain more warlock spells of your choice that can be cast i
                   }]}
 
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             13 {:+features
                 [{:id :warlock/mystic-arcanum-7th
@@ -155,7 +155,7 @@ At higher levels, you gain more warlock spells of your choice that can be cast i
                   }]}
 
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             17 {:+features
                 [{:id :warlock/mystic-arcanum-9th
@@ -173,7 +173,7 @@ At higher levels, you gain more warlock spells of your choice that can be cast i
                   }]}
 
             19 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             20 {:+features
                 [{:id :warlock/eldritch-master
                   :name "Eldritch Master"

--- a/resources/sources/dnd5e/classes/wizard.edn
+++ b/resources/sources/dnd5e/classes/wizard.edn
@@ -67,13 +67,13 @@ For example, if you’re a 4th-level wizard, you can recover up to two levels wo
                  :max-options 1}]}
 
             4 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
             8 {:+features
-               [:ability-improvement]}
+               [:abi-or-feat]}
             12 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             16 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
 
             18 {:+features
                 [{:id :wizard/spell-mastery
@@ -96,7 +96,7 @@ By spending 8 hours in study, you can exchange one or both of the spells you cho
                  ]}
 
             19 {:+features
-                [:ability-improvement]}
+                [:abi-or-feat]}
             20 {:+features
                 [{:id :wizard/signature-spells
                   :name "Signature Spells"

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -63,6 +63,11 @@
 (defstyled feature-options-style
   [:.feature>.content {:padding "0 12px"}
    [:.desc style/metadata]]
+
+  ; features provided by another feature:
+  [:.feature.provided {:margin-left "16px"}
+     [:.title {:font-size "1.1em"}]]
+
   [:.class.feature-option.disabled {:color "#ccc"
                                     :cursor 'default}
    [:.name {:font-style 'italic
@@ -239,8 +244,9 @@
 
              ^{:key instance-id}
              [bind-fields
-              [:div.feature
-               [:h3
+              [:div.feature {:class (when (> (count (:wish/sort f)) 2)
+                                      "provided")}
+               [:h3.title
                 (:name f)
                 (when-let [n (:wish/instance f)]
                   (str " #" (inc n)))

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -244,7 +244,7 @@
                 (:name f)
                 (when-let [n (:wish/instance f)]
                   (str " #" (inc n)))
-                (str "—Sort: `" (or (:wish/sort f)
+                #_(str "—Sort: `" (or (:wish/sort f)
                                    "(no sort)")
                      "`")]
 

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -243,7 +243,10 @@
                [:h3
                 (:name f)
                 (when-let [n (:wish/instance f)]
-                  (str " #" (inc n)))]
+                  (str " #" (inc n)))
+                (str "—Sort: `" (or (:wish/sort f)
+                                   "(no sort)")
+                     "`")]
 
                [:div.content
                 (when-let [desc (:desc f)]

--- a/src/cljs/wish/sources/compiler.cljs
+++ b/src/cljs/wish/sources/compiler.cljs
@@ -10,6 +10,7 @@
             [wish.sources.compiler.limited-use :refer [compile-limited-use]]
             [wish.sources.compiler.lists :refer [add-to-list inflate-items install-deferred-lists]]
             [wish.sources.compiler.race :refer [declare-race declare-subrace install-deferred-subraces]]
+            [wish.sources.compiler.util :as util]
             [wish.sources.core :refer [find-feature]]
             [wish.util :refer [deep-merge inc-or ->map process-map]]))
 
@@ -143,16 +144,7 @@
                                                     inc-or 2)
 
                                             ; ensure :wish/sorts exists with :wish/sort
-                                            (update :wish/sorts
-                                                    #(cond-> %
-                                                       (and (:wish/sort a)
-                                                            (nil? %))
-                                                       (as-> _ ;ignore the old value
-                                                         (list (:wish/sort a)))
-
-                                                       ; conj new sort, if any
-                                                       (:wish/sort b)
-                                                       (conj (:wish/sort b)))))
+                                            (util/combine-sorts b))
 
                                         ; just use the newer
                                         b)))

--- a/src/cljs/wish/sources/compiler.cljs
+++ b/src/cljs/wish/sources/compiler.cljs
@@ -355,14 +355,22 @@
                                 (dissoc :wish/sorts)
                                 (assoc :wish/sort (-> (:wish/sorts providing-feature)
                                                       (reverse)
-                                                      (nth instance-n))))
+                                                      (nth instance-n nil))))
                             providing-feature)]
 
     (if (or (empty? options-chosen)
 
             ; don't apply any options if the feature doesn't apply to this state
             ; (EX: racial feature options on the class, or vice versa)
-            (not providing-feature))
+            (not providing-feature)
+
+            ; also, if the providing feature is instanced, don't apply we don't have
+            ; enough instances available (IE: they leveled up, selected, then leveled down)
+            (when (:instanced? providing-feature)
+              ; NOTE: :wish/instances can be nil if it's a single instance of the
+              ; feature, but we know it exists with *at least* one because (:instanced?)
+              ; is true
+              (>= instance-n (:wish/instances providing-feature 1))))
       state
 
       (let [option-value (first options-chosen)

--- a/src/cljs/wish/sources/compiler.cljs
+++ b/src/cljs/wish/sources/compiler.cljs
@@ -182,16 +182,11 @@
                (fn [features]
                  (reduce-kv
                    (fn [m feature-id v]
-                     (let [instances (or (:wish/instances v)
-
-                                         ; the v could just be a number
-                                         ; of instances
-                                         (when (number? v)
-                                           v))]
+                     (let [instances (:wish/instances v)]
                        ; if the value is just a map indicating that this
                        ; is a secondary instance of the feature,
                        ; just load the feature as normal (2nd branch)
-                       (if (and (map? v)
+                       (if (and (:id v)
                                 (not instances))
                          ; ensure it's compiled
                          (assoc m feature-id (compile-feature v))
@@ -201,16 +196,17 @@
                          (let [from-state (get-in s [:features feature-id])
                                ; this is a bit obnoxious to avoid eager evaluation
                                ; from-state could be a number here
-                               f (if (map? from-state)
+                               f (if (:id from-state)
+                                   ; already inflated
                                    from-state
+
+                                   ; inflate the feature
                                    (when data-source
                                      (find-feature data-source feature-id)))
 
-                               ; include :wish/instances
+                               ; include :wish/instances and :wish/sort
                                f (when f
-                                   (if instances
-                                     (assoc f :wish/instances instances)
-                                     f))]
+                                   (merge v f))]
                            (assoc m feature-id f)))))
                    features
                    features)))

--- a/src/cljs/wish/sources/compiler.cljs
+++ b/src/cljs/wish/sources/compiler.cljs
@@ -182,32 +182,31 @@
                (fn [features]
                  (reduce-kv
                    (fn [m feature-id v]
-                     (let [instances (:wish/instances v)]
-                       ; if the value is just a map indicating that this
-                       ; is a secondary instance of the feature,
-                       ; just load the feature as normal (2nd branch)
-                       (if (and (:id v)
-                                (not instances))
-                         ; ensure it's compiled
-                         (assoc m feature-id (compile-feature v))
+                     ; if the value is just a map indicating that this
+                     ; is a secondary instance of the feature,
+                     ; just load the feature as normal (2nd branch)
+                     (if (and (:id v)
+                              (not (:wish/instances v)))
+                       ; ensure it's compiled
+                       (assoc m feature-id (compile-feature v))
 
-                         ; pull it out of the state (or data source,
-                         ; if we have one)
-                         (let [from-state (get-in s [:features feature-id])
-                               ; this is a bit obnoxious to avoid eager evaluation
-                               ; from-state could be a number here
-                               f (if (:id from-state)
-                                   ; already inflated
-                                   from-state
+                       ; pull it out of the state (or data source, if we have one)
+                       (let [from-state (get-in s [:features feature-id])
 
-                                   ; inflate the feature
-                                   (when data-source
-                                     (find-feature data-source feature-id)))
+                             ; this is a bit obnoxious to avoid eager evaluation
+                             ; from-state could be a number here
+                             f (if (:id from-state)
+                                 ; already inflated
+                                 from-state
 
-                               ; include :wish/instances and :wish/sort
-                               f (when f
-                                   (merge v f))]
-                           (assoc m feature-id f)))))
+                                 ; inflate the feature
+                                 (when data-source
+                                   (find-feature data-source feature-id)))
+
+                             ; include :wish/instances and :wish/sort
+                             f (when f
+                                 (merge v f))]
+                         (assoc m feature-id f))))
                    features
                    features)))
 

--- a/src/cljs/wish/sources/compiler/entity.cljs
+++ b/src/cljs/wish/sources/compiler/entity.cljs
@@ -7,11 +7,13 @@
   [features]
   (when features
     (cond
-      (vector? features) (reduce
-                           (fn [m feature]
+      (vector? features) (reduce-kv
+                           (fn [m i feature]
                              (if (map? feature)
-                               (assoc m (:id feature) feature)
-                               (assoc m feature true)))
+                               (assoc m
+                                      (:id feature)
+                                      (assoc feature :wish/sort [0 i]))
+                               (assoc m feature {:wish/sort [0 i]})))
                            {}
                            features)
       (map? features) features

--- a/src/cljs/wish/sources/compiler/util.cljs
+++ b/src/cljs/wish/sources/compiler/util.cljs
@@ -1,0 +1,38 @@
+(ns ^{:author "Daniel Leong"
+      :doc "compiler-specific routines"}
+  wish.sources.compiler.util)
+
+(def ^:private sort-reversed (partial sort (fn [a b]
+                                             (compare b a))))
+
+(defn combine-sorts
+  "Given two entities that might `:wish/sort`,
+   combine them into `:wish/sorts` on the first one"
+  [a b]
+  (cond
+    ; easy case
+    (and (:wish/sorts a)
+         (:wish/sort b))
+    (-> a
+        (update :wish/sorts conj (:wish/sort b))
+        (update :wish/sorts sort-reversed))
+
+    ; easiest case; no new sort to add
+    (:wish/sorts a)
+    a
+
+    ; no existing :wish/sorts
+    (and (:wish/sort a)
+         (:wish/sort b))
+    (assoc a :wish/sorts (sort-reversed (list (:wish/sort a)
+                                              (:wish/sort b))))
+
+    ; single entries
+    (:wish/sort a)
+    (assoc a :wish/sorts (list (:wish/sort a)))
+
+    (:wish/sort b)
+    (assoc a :wish/sorts (list (:wish/sort b)))
+
+    ; just in case:
+    :else a))

--- a/src/cljs/wish/subs.cljs
+++ b/src/cljs/wish/subs.cljs
@@ -11,7 +11,7 @@
             [wish.sources.compiler :refer [apply-directives inflate]]
             [wish.sources.compiler.lists :as lists]
             [wish.sources.core :as src :refer [find-class find-race]]
-            [wish.util :refer [deep-merge]]))
+            [wish.util :refer [deep-merge padded-compare]]))
 
 (reg-sub :device-type :device-type)
 (reg-sub :showing-overlay :showing-overlay)
@@ -393,17 +393,6 @@
                ; if not provided, it's always available
                true)))
     values))
-
-(defn- padded-compare
-  "Given two vectors of numbers, this will pad them both
-   with zeroes to be the same length, then call compare"
-  [a b]
-  (let [longest (max (count a)
-                     (count b))]
-    ; FIXME this is terribly inefficient
-    (compare
-      (vec (concat a (repeat (- longest (count a)) 0)))
-      (vec (concat b (repeat (- longest (count b)) 0))))))
 
 (defn- inflate-feature-options
   [[features options attrs sheet data-source]]

--- a/src/cljs/wish/subs.cljs
+++ b/src/cljs/wish/subs.cljs
@@ -414,7 +414,8 @@
                               (update v :values (partial filter filter-fn))
                               v))
                           )]
-                  (meta entry)))))))
+                  (meta entry)))))
+       (sort-by (comp :wish/sort second))))
 
 (defn- only-feature-options
   [[features options attrs sheet data-source]]

--- a/src/cljs/wish/subs.cljs
+++ b/src/cljs/wish/subs.cljs
@@ -325,8 +325,8 @@
                                       n)))
                              (assoc-in [1 :wish/instance] n)
                              (update-in [1 :wish/sort] (fn [old-sort]
-                                                         (or old-sort
-                                                             sort-key)))))
+                                                         (or sort-key
+                                                             old-sort)))))
                        (range total-instances)
                        (concat
                          ; to ensure we get all instances, even if we don't have enough
@@ -394,6 +394,17 @@
                true)))
     values))
 
+(defn- padded-compare
+  "Given two vectors of numbers, this will pad them both
+   with zeroes to be the same length, then call compare"
+  [a b]
+  (let [longest (max (count a)
+                     (count b))]
+    ; FIXME this is terribly inefficient
+    (compare
+      (vec (concat a (repeat (- longest (count a)) 0)))
+      (vec (concat b (repeat (- longest (count b)) 0))))))
+
 (defn- inflate-feature-options
   [[features options attrs sheet data-source]]
   (->> features
@@ -424,7 +435,7 @@
                               v))
                           )]
                   (meta entry)))))
-       (sort-by (comp :wish/sort second))))
+       (sort-by (comp :wish/sort second) padded-compare)))
 
 (defn- only-feature-options
   [[features options attrs sheet data-source]]

--- a/src/cljs/wish/subs.cljs
+++ b/src/cljs/wish/subs.cljs
@@ -309,6 +309,7 @@
        (mapcat (fn [[id f :as entry]]
                  (if (:instanced? f)
                    (let [total-instances (:wish/instances f 1)
+                         sorts (:wish/sorts f)
                          {:wish/keys [container-id]} (meta entry)]
                      (map
                        (fn [n]
@@ -322,7 +323,11 @@
                                       (name container-id)
                                       "#"
                                       n)))
-                             (assoc-in [1 :wish/instance] n)))
+                             (assoc-in [1 :wish/instance] n)
+                             (update-in [1 :wish/sort] (fn [old-sort]
+                                                         (or old-sort
+                                                             (when (< n (count sorts))
+                                                               (nth sorts n)))))))
                        (range total-instances)))
 
                    ; normal feature

--- a/src/cljs/wish/subs.cljs
+++ b/src/cljs/wish/subs.cljs
@@ -312,7 +312,7 @@
                          sorts (:wish/sorts f)
                          {:wish/keys [container-id]} (meta entry)]
                      (map
-                       (fn [n]
+                       (fn [n sort-key]
                          (-> entry
                              (assoc-in
                                [1 :wish/instance-id]
@@ -326,9 +326,13 @@
                              (assoc-in [1 :wish/instance] n)
                              (update-in [1 :wish/sort] (fn [old-sort]
                                                          (or old-sort
-                                                             (when (< n (count sorts))
-                                                               (nth sorts n)))))))
-                       (range total-instances)))
+                                                             sort-key)))))
+                       (range total-instances)
+                       (concat
+                         ; to ensure we get all instances, even if we don't have enough
+                         ; sorts, we pad the end of the list of sorts with nil
+                         (reverse sorts)
+                         (repeat nil))))
 
                    ; normal feature
                    [entry])))))

--- a/src/cljs/wish/util.cljs
+++ b/src/cljs/wish/util.cljs
@@ -57,6 +57,26 @@
                       (when-not (= old v)
                         v))))
 
+(defn padded-compare
+  "Given two vectors of numbers, this will compare them as if the
+   shorter were padded with zeroes to be the same length as the
+   longer. This allows for orderings like:
+
+    [0 0] [0 0 0] [4 0] [4 0 0]"
+  [a b]
+  (let [longest (max (count a)
+                     (count b))]
+    (if (= 0 longest)
+      0 ; quick reject
+
+      (loop [i 0]
+        (let [c (compare (nth a i 0)
+                         (nth b i 0))
+              nexti (inc i)]
+          (if (and (zero? c) (< nexti longest))
+            (recur nexti)
+            c))))))
+
 (defn click>evts
   "Returns an on-click handler that dispatches the given events
    and prevents the default on-click events"

--- a/src/cljs/wish/views/widgets/limited_select.cljs
+++ b/src/cljs/wish/views/widgets/limited_select.cljs
@@ -19,7 +19,9 @@
   (let [const-max (-> accepted? meta :const)]
     (if (= 1 const-max)
       ; act like a radio button
-      {key-clicked true}
+      (if (get selections key-clicked)
+        {}
+        {key-clicked true})
 
       (let [updated (update-in selections [key-clicked] not)]
         (if (accepted? (merge

--- a/test/cljs/wish/runner.cljs
+++ b/test/cljs/wish/runner.cljs
@@ -16,6 +16,7 @@
             [wish.sources.compiler.fun-test]
             [wish.sources.compiler.limited-use-test]
             [wish.sources.compiler.lists-test]
+            [wish.sources.compiler.util-test]
             [wish.sources.composite-test]
             [wish.subs-test]
             [wish.util-test]

--- a/test/cljs/wish/sources/compiler/entity_mod_test.cljs
+++ b/test/cljs/wish/sources/compiler/entity_mod_test.cljs
@@ -56,22 +56,25 @@
 
   (testing "Features special case"
     (let [features-with-a (apply-entity-mod {} {:+features [:a]})]
-      (is (= {:features {:a 1 :b {:id :b}}}
+      (is (= {:features {:a {:wish/instances 1}
+                         :b {:id :b}}}
              (apply-entity-mod
                features-with-a
                {:+features {:b {:id :b}}})))
-      (is (= {:features {:a 1 :b {:id :b}}}
+      (is (= {:features {:a {:wish/instances 1}
+                         :b {:id :b}}}
              (apply-entity-mod
                features-with-a
                {:+features [{:id :b}]})))
-      (is (= {:features {:a 1 :b 1}}
+      (is (= {:features {:a {:wish/instances 1}
+                         :b {:wish/instances 1}}}
              (apply-entity-mod
                features-with-a
                {:+features [:b]})))))
 
   (testing "Multiple Feature instances"
     (let [features-with-a (apply-entity-mod {} {:+features [:a]})]
-      (is (= {:features {:a 2}}
+      (is (= {:features {:a {:wish/instances 2}}}
              (apply-entity-mod
                features-with-a
                {:+features [:a]}))))))

--- a/test/cljs/wish/sources/compiler/util_test.cljs
+++ b/test/cljs/wish/sources/compiler/util_test.cljs
@@ -1,0 +1,33 @@
+(ns wish.sources.compiler.util-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [wish.sources.compiler.util :refer [combine-sorts]]))
+
+(defn do-combine-sorts
+  [a b]
+  (:wish/sorts (combine-sorts a b)))
+
+(deftest combine-sorts-test
+  (testing "No existing sorts, one sort"
+    (is (= '([0 1])
+           (do-combine-sorts
+             {:wish/sort [0 1]}
+             {})))
+    (is (= '([0 1])
+           (do-combine-sorts
+             {}
+             {:wish/sort [0 1]}))))
+  (testing "No existing sorts, both sort"
+    (is (= '([0 2] [0 1])
+           (do-combine-sorts
+             {:wish/sort [0 1]}
+             {:wish/sort [0 2]})))
+    (is (= '([0 2] [0 1])
+           (do-combine-sorts
+             {:wish/sort [0 2]}
+             {:wish/sort [0 1]}))))
+  (testing "Existing sorts"
+    (is (= '([0 2] [0 1])
+           (do-combine-sorts
+             {:wish/sorts '([0 1])}
+             {:wish/sort [0 2]})))))
+

--- a/test/cljs/wish/sources/compiler_test.cljs
+++ b/test/cljs/wish/sources/compiler_test.cljs
@@ -475,4 +475,20 @@
                          :classes
                          :cleric)]
       (is (= [0 0] (-> class-def :features :first :wish/sort)))
-      (is (= [0 1] (-> class-def :features :second :wish/sort))))))
+      (is (= [0 1] (-> class-def :features :second :wish/sort)))))
+
+  (testing ":+features"
+    (let [class-def (-> (compile-directives
+                           [[:!declare-class
+                             {:id :cleric
+                              :features
+                              [{:id :first}]
+                              :&levels
+                              {2 {:+features [{:id :second}]}}}]])
+                         :classes
+                         :cleric
+                         (assoc :level 3) ; ensure sort is based on level *added*,
+                                          ; not level *when added*
+                         (inflate nil {}))]
+      (is (= [0 0] (-> class-def :features :first :wish/sort)))
+      (is (= [2 0] (-> class-def :features :second :wish/sort))))))

--- a/test/cljs/wish/sources/compiler_test.cljs
+++ b/test/cljs/wish/sources/compiler_test.cljs
@@ -542,19 +542,24 @@
                     {:id :cleric
                      :&levels
                      {1 {:+features [:instanced]}
-                      2 {:+features [:instanced]}}}]])
+                      2 {:+features [:instanced]}
+                      3 {:+features [:instanced]}
+                      }}]])
           class-def (-> state
                         :classes
                         :cleric
-                        (assoc :level 3)
+                        (assoc :level 4)
                         (inflate (->DataSource :id state)
                                  {:instanced#rogue#0
                                   {:id :instanced
                                    :value [:provide/child]}
                                   :instanced#rogue#1
                                   {:id :instanced
+                                   :value [:provide/child]}
+                                  :instanced#rogue#2
+                                  {:id :instanced
                                    :value [:provide/child]}}))]
-      (is (= '([2 0] [1 0])
+      (is (= '([3 0] [2 0] [1 0])
              (-> class-def :features :instanced :wish/sorts)))
-      (is (= '([2 0 1] [1 0 1])
+      (is (= '([3 0 1] [2 0 1] [1 0 1])
              (-> class-def :features :child :wish/sorts))))))

--- a/test/cljs/wish/sources/compiler_test.cljs
+++ b/test/cljs/wish/sources/compiler_test.cljs
@@ -455,3 +455,24 @@
                    :limited-uses
                    :spell-points
                    :restore-trigger)))))))
+
+; as features get compiled and installed into entities,
+; we add :wish/sort to them to ensure that, when iterating
+; over all the features installed into an entity we can do
+; so in the order the data-source author intended.
+; This includes sorting features provided by a feature to
+; come immediately after the feature they were provided by,
+; and sorting features added by level-scaling in ascending
+; order by the level they were added
+(deftest sort-key-test
+  (testing "Basic :features"
+    (let [class-def (->> (compile-directives
+                           [[:!declare-class
+                             {:id :cleric
+                              :features
+                              [{:id :first}
+                               {:id :second}]}]])
+                         :classes
+                         :cleric)]
+      (is (= [0 0] (-> class-def :features :first :wish/sort)))
+      (is (= [0 1] (-> class-def :features :second :wish/sort))))))

--- a/test/cljs/wish/util_test.cljs
+++ b/test/cljs/wish/util_test.cljs
@@ -1,6 +1,6 @@
 (ns wish.util-test
   (:require [cljs.test :refer-macros [deftest testing is]]
-            [wish.util :refer [->map update-each-value]]))
+            [wish.util :refer [->map padded-compare update-each-value]]))
 
 (deftest ->map-test
   (testing "Vector ->map"
@@ -25,3 +25,17 @@
            (update-each-value
              {:one 1 :three 3}
              inc)))))
+
+(deftest padded-compare-test
+  (testing "Compare same length"
+    (is (= 0 (padded-compare [1] [1])))
+    (is (= 0 (padded-compare [1 1] [1 1])))
+    (is (= 0 (padded-compare [1 1 1] [1 1 1]))))
+  (testing "Compare (count a) < (count b) "
+    (is (= 0 (padded-compare [1] [1 0])))
+    (is (< (padded-compare [1] [1 1])
+           0)))
+  (testing "Compare (count a) > (count b) "
+    (is (= 0 (padded-compare [1 0] [1])))
+    (is (> (padded-compare [1 1] [1])
+           0))))


### PR DESCRIPTION
Adds `:wish/sort` key to all features returned from the `:class-features-with-options` and `:race-features-with-options` subscriptions.

This PR will also close #81 by providing the `:abi-or-feat` feature as a drop-in replacement for `:ability-improvement` whose UX is significantly improved by the changes here. In particular, features provided by the options of other features (IE: selecting "Feat" from the `:abi-or-feat` features provides an instance of `:feat`) will appear slightly indented to indicate the dependency.