### PR TITLE
Support Transit sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ out
 .lein-failures
 .cljs_nashorn_repl
 .repl
+.bin
 nashorn_code_cache
 .planck_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,6 @@ addons:
     chrome: stable
 
 before_script:
-    # plk depends on clojure
-    - curl -O https://download.clojure.org/install/linux-install-1.9.0.381.sh
-    - chmod +x linux-install-1.9.0.381.sh
-    - sudo ./linux-install-1.9.0.381.sh
-
-    # build planck from scratch since we need the latest version
-    - sudo apt-get install javascriptcoregtk-3.0 libglib2.0-dev libzip-dev libcurl4-gnutls-dev libicu-dev
-    - git clone --depth 1 https://github.com/planck-repl/planck.git
-    - (cd planck && script/build --fast && sudo script/install)
-    - planck --version
-
-    # set up the plk tool
-    - export PATH=$PATH:$PWD/planck/planck-sh/
-
     # set the version variable
     - export WISH_VERSION=$(git rev-parse --short HEAD)
 

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                  [cljs-ajax "0.7.4"]
                  [com.cemerick/url "0.1.1"]
                  [alandipert/storage-atom "2.0.1"]
+                 [com.cognitect/transit-cljs "0.8.256"]
 
                  [cljsjs/react-virtualized "9.18.5-1"]
                  [cljsjs/react-swipeable-views "0.12.18-0"]

--- a/scripts/compile-builtin-sources
+++ b/scripts/compile-builtin-sources
@@ -17,5 +17,5 @@ fi
 
 for s in "${sources[@]}"; do
     echo "Compiling $s"
-    scripts/compile-source.cljs "$s"
+    scripts/wish-compiler "resources/sources/$s" "resources/public/sources/$s.transit.json"
 done

--- a/scripts/wish-compiler
+++ b/scripts/wish-compiler
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# auto-download latest release bin
+if ! [ -d ".bin" ] || ! [ -f ".bin/wish-compiler" ]; then
+    mkdir .bin
+    url=$(curl -s https://api.github.com/repos/dhleong/wish-compiler/releases/latest \
+        | grep "browser_download_url" \
+        | cut -d '"' -f 4)
+    curl $url -Lo .bin/wish-compiler
+    chmod +x .bin/wish-compiler
+fi
+
+.bin/wish-compiler "$@"

--- a/src/cljs/wish/providers/wish.cljs
+++ b/src/cljs/wish/providers/wish.cljs
@@ -14,7 +14,9 @@
 
 (def ^:private builtin-sources
   {"dnd5e-srd" {:name "D&D 5e System Reference Document"
-                :path "/dnd5e.edn.json"}})
+                ;; :path "/dnd5e.edn.json"
+                :path "/dnd5e.transit.json"
+                }})
 
 (deftype WishProvider []
   IProvider

--- a/src/cljs/wish/sources.cljs
+++ b/src/cljs/wish/sources.cljs
@@ -17,29 +17,34 @@
 ; cache of *compiled* sources by id
 (defonce ^:private loaded-sources (atom {}))
 
+(defn- read-transit-directives [raw]
+  (t/read (t/reader :json) raw))
+
+(defn- read-edn-directives [raw]
+  (loop [reader (string-push-back-reader raw)
+         directives []]
+    (if-let [d (edn/read reader)]
+      ; keep loading directives
+      (recur reader (conj directives d))
+
+      ; done!
+      directives)))
+
 (defn- compile-raw-source
   [{:keys [kind] :as sheet} id raw]
-  (if (= "wish" (namespace id))
-    (do
-      (log/info "Compile transit!")
-      (->DataSource
-        id
-        (->> raw
-             (t/read (t/reader :json))
-             (compile-directives)
-             (sheets/post-compile kind))))
+  (let [directives (if (= (subs raw 0 2) "[[")
+                     (do
+                       (log "Read transit for " id)
+                       (read-transit-directives raw))
 
-    (loop [reader (string-push-back-reader raw)
-           directives []]
-      (if-let [d (edn/read reader)]
-        ; keep loading directives
-        (recur reader (conj directives d))
-
-        (->DataSource
-          id
-          (->> directives
-               (compile-directives)
-               (sheets/post-compile kind)))))))
+                     (do
+                       (log "Read edn for " id)
+                       (read-edn-directives raw)))]
+    (->DataSource
+      id
+      (->> directives
+           (compile-directives)
+           (sheets/post-compile kind)))))
 
 (defn- load-source!
   "Returns a channel that signals with [err] or [nil source] when done"


### PR DESCRIPTION
Uses [wish-compiler](https://github.com/dhleong/wish-compiler) to compile sources to Transit instead of EDN, and adds support for loading Transit-encoded sources.

According to some super non-scientific testing in #9, encoding data sources in Transit could make them load ~30% faster than EDN-encoded sources. As a bonus, using `wish-compiler` also speeds up build/deploy times on Travis by ~30% as well.

Closes #9 