### PR TITLE
CI: Attempt to skip `lein build` step when not on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
     - scripts/compile-builtin-sources
 
 after_success:
-    - [ "$TRAVIS_BRANCH" = "master" ] && lein build
+    - if [ "$TRAVIS_BRANCH" = master ]; then lein build || travis_terminate 1; fi
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
     - scripts/compile-builtin-sources
 
 after_success:
-    - if [ "$TRAVIS_BRANCH" = master ]; then lein build || travis_terminate 1; fi
+    - if [ "$TRAVIS_BRANCH" = master ] && [ -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then lein build || travis_terminate 1; fi
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
     - scripts/compile-builtin-sources
 
 after_success:
-    - lein build
+    - [ "$TRAVIS_BRANCH" = "master" ] && lein build
 
 cache:
     directories:

--- a/scripts/wish-compiler
+++ b/scripts/wish-compiler
@@ -3,20 +3,36 @@
 # auto-download latest release bin
 if ! [ -d ".bin" ] || ! [ -f ".bin/wish-compiler" ]; then
     mkdir .bin 2> /dev/null
-    response=$(curl -s https://api.github.com/repos/dhleong/wish-compiler/releases/latest)
+
+    # if provided, use a github token to fetch (higher rate limit)
+    header=""
+    if ! [ -z "$GITHUB_DEPLOY" ]; then
+        echo "Using auth token"
+        header="Authorization: token $GITHUB_DEPLOY"
+    fi
+
+    # fetch the URL
+    response=$(curl -s -H "$header" https://api.github.com/repos/dhleong/wish-compiler/releases/latest)
     url=$(echo "$response" \
         | grep "browser_download_url" \
         | cut -d '"' -f 4)
 
-    echo "Fetching wish-compiler: $url"
-    curl $url -Lo .bin/wish-compiler || echo "Error getting latest compiler version: $response"
+    # fetch the binary
+    if ! [ -z "$url" ]; then
+        echo "Fetching wish-compiler: $url"
+        curl $url -Lo .bin/wish-compiler
+    else
+        echo "Error getting latest compiler version: $response"
+    fi
 
     if ! [ -f ".bin/wish-compiler" ]; then
         echo "Failed to download wish-compiler"
         exit 1
     fi
 
+    # make it executable
     chmod +x .bin/wish-compiler
 fi
 
+# go!
 .bin/wish-compiler "$@"


### PR DESCRIPTION
We only deploy from master, so doing this just adds an unnecessary
delay to CI checks for branches and PRs