### PR TITLE
Connect to `wish-server` and listen for push events, as appropriate

### DIFF
--- a/dev/cljs/wish/config.cljs
+++ b/dev/cljs/wish/config.cljs
@@ -10,3 +10,5 @@
 (def server-root "")
 
 (def gdrive-client-id "661182319990-1uerkr0pue6k60a83atj2f58md95fb1b.apps.googleusercontent.com")
+
+(def push-server "http://localhost:4321")

--- a/prod/cljs/wish/config.cljs
+++ b/prod/cljs/wish/config.cljs
@@ -10,3 +10,5 @@
 (def server-root "/wish")
 
 (def gdrive-client-id "661182319990-3aa8akj9fh8eva9lf7bt02621q2i18s6.apps.googleusercontent.com")
+
+(def push-server "https://wish-server.now.sh")

--- a/src/cljs/wish/events.cljs
+++ b/src/cljs/wish/events.cljs
@@ -1,5 +1,5 @@
 (ns wish.events
-  (:require-macros [wish.util.log :refer [log]])
+  (:require-macros [wish.util.log :as log :refer [log]])
   (:require [clojure.string :as str]
             [re-frame.core :refer [dispatch reg-event-db reg-event-fx
                                    path
@@ -209,6 +209,7 @@
 
       ; delete the sheet source to trigger a reload
       [:db :sheet-sources sheet-id] nil)))
+
 
 ; ======= sheet-related ====================================
 
@@ -681,3 +682,16 @@
     (if-not (= current-ids interested-ids)
       (log "Drop un-interesting sesssion; was " interested-ids "; now " current-ids)
       {:push/connect session-id})))
+
+(reg-event-fx
+  :reload-changed!
+  [trim-v (inject-cofx ::inject/sub [:active-sheet-id])]
+  (fn [{:keys [active-sheet-id]} [changed-ids]]
+    (when (> (count changed-ids) 1)
+      ; TODO:
+      (log/todo "Support reloading data sources as well as sheets"))
+
+    (when (contains? changed-ids active-sheet-id)
+      ; trigger sheet data reload
+      {:load-sheet! active-sheet-id})))
+

--- a/src/cljs/wish/providers.cljs
+++ b/src/cljs/wish/providers.cljs
@@ -214,3 +214,18 @@
       (throw (js/Error. (str "No provider instance for " sheet-id
                                "(" provider-id " / " pro-sheet-id ")"))))))
 
+(defn watch-auth-map
+  "Given a collection of sheet IDs, generate an appropate
+   auth-map for use with the wish-server watch session API"
+  [sheet-ids]
+  (->> sheet-ids
+       (map (comp first unpack-id))
+       (into #{})
+       (reduce
+         (fn [m provider-id]
+           (if-let [auth (some-> provider-id
+                                 (provider-key :inst)
+                                 (provider/watch-auth))]
+             (assoc m provider-id auth)
+             m))
+         {})))

--- a/src/cljs/wish/providers/caching.cljs
+++ b/src/cljs/wish/providers/caching.cljs
@@ -140,7 +140,11 @@
             (swap! dirty?-storage disj file-id))
 
           ; return the result as-is
-          result))))
+          result)))
+
+  (watch-auth [this]
+    ; delegate
+    (provider/watch-auth base)))
 
 (defn with-caching [base-provider]
   (let [cache-id (keyword (str (name (provider/id base-provider))

--- a/src/cljs/wish/providers/core.cljs
+++ b/src/cljs/wish/providers/core.cljs
@@ -50,7 +50,12 @@
      The original `data` *may* be provided, which you can use to
      update `:name`, for example, but it may also be omitted.
      `data-str` is in the same string format that should be
-     returned by `load-raw`."))
+     returned by `load-raw`.")
+
+  (watch-auth
+    [this]
+    "Generate the auth data needed to watch changes to files provided
+     by this provider, or nil if that's not supported by this provider"))
 
 (defn signed-out-err?
   "Check if the given error was caused by not being signed into the provider"

--- a/src/cljs/wish/providers/gdrive.cljs
+++ b/src/cljs/wish/providers/gdrive.cljs
@@ -217,12 +217,15 @@
           (.-currentUser)
           (.get)))
 
+(defn- auth-response []
+  (some-> (current-user)
+          (.getAuthResponse)))
+
 (defn- access-token
   "When logged in, get the current user's access token"
   []
-  (-> (current-user)
-      (.getAuthResponse)
-      (.-access_token)))
+  (some-> (auth-response)
+          (.-access_token)))
 
 (defn- update-signin-status!
   [signed-in?]
@@ -519,7 +522,12 @@
           data-str))
 
       ; not ready? don't try
-      (to-chan [[(js/Error. "No network; unable to save sheet") nil]]))))
+      (to-chan [[(js/Error. "No network; unable to save sheet") nil]])))
+
+  (watch-auth [this]
+    (when-let [resp (auth-response)]
+      {:id_token (.-id_token resp)
+       :access_token (access-token)})))
 
 (defn create-provider []
   (->GDriveProvider))

--- a/src/cljs/wish/providers/wish.cljs
+++ b/src/cljs/wish/providers/wish.cljs
@@ -60,7 +60,11 @@
     (to-chan [[(js/Error. "Not implemented") nil]]))
 
   (save-sheet [this file-id data data-str]
-    (to-chan [[(js/Error. "Not implemented") nil]])))
+    (to-chan [[(js/Error. "Not implemented") nil]]))
+
+  (watch-auth [this]
+    ; not supported:
+    nil))
 
 (defn create-provider []
   (->WishProvider))

--- a/src/cljs/wish/providers/wish.cljs
+++ b/src/cljs/wish/providers/wish.cljs
@@ -3,11 +3,11 @@
   wish.providers.wish
   (:require-macros [wish.util.log :refer [log]])
   (:require [clojure.core.async :refer [chan put! to-chan <! >!]]
-            [ajax.core :refer [GET]]
             [wish.config :as config]
             [wish.providers.core :refer [IProvider]]
             [wish.sheets.util :refer [make-id]]
-            [wish.util :refer [>evt]]))
+            [wish.util :refer [>evt]]
+            [wish.util.http :refer [GET]]))
 
 (def ^:private data-root (str config/server-root
                               "/sources"))
@@ -30,21 +30,10 @@
 
   (load-raw
     [this id]
-    (let [ch (chan)
-          url (str data-root (:path (builtin-sources id)))]
-      (if url
-        (GET url
-             {:handler (fn [raw]
-                         (log "Loaded " url)
-                         (put! ch [nil raw]))
-              :response-format :text
-              :error-handler (fn [e]
-                               (put! ch [e]))})
+    (if-let [url (str data-root (:path (builtin-sources id)))]
+      (GET url {:response-format :text})
 
-        (put! ch [(js/Error. (str "No such source: " id))]))
-
-      ; return the ch
-      ch))
+      (to-chan [[(js/Error. (str "No such source: " id))]])))
 
   (query-data-sources [this]
     (>evt [:add-data-sources
@@ -60,11 +49,7 @@
     (to-chan [[(js/Error. "Not implemented") nil]]))
 
   (save-sheet [this file-id data data-str]
-    (to-chan [[(js/Error. "Not implemented") nil]]))
-
-  (watch-auth [this]
-    ; not supported:
-    nil))
+    (to-chan [[(js/Error. "Not implemented") nil]])))
 
 (defn create-provider []
   (->WishProvider))

--- a/src/cljs/wish/providers/wish.cljs
+++ b/src/cljs/wish/providers/wish.cljs
@@ -49,7 +49,11 @@
     (to-chan [[(js/Error. "Not implemented") nil]]))
 
   (save-sheet [this file-id data data-str]
-    (to-chan [[(js/Error. "Not implemented") nil]])))
+    (to-chan [[(js/Error. "Not implemented") nil]]))
+
+  (watch-auth [this]
+    ; not supported
+    nil))
 
 (defn create-provider []
   (->WishProvider))

--- a/src/cljs/wish/push.cljs
+++ b/src/cljs/wish/push.cljs
@@ -1,0 +1,20 @@
+(ns ^{:author "Daniel Leong"
+      :doc "Push-notification API"}
+  wish.push
+  (:require [wish.config :as config]
+            [wish.providers :as providers]
+            [wish.util.http :refer [POST]]))
+
+(def push-server-version "v1")
+
+(def ^:private push-url-base (str config/push-server "/" push-server-version))
+
+(defn create-session [interested-ids]
+  (when-let [auth (providers/watch-auth-map interested-ids)]
+    (POST (str push-url-base "/push/sessions")
+          {:auth auth
+
+           ; default serialization of a keyword drops the namespace
+           :ids (map (fn [id]
+                       (subs (str id) 1))
+                     interested-ids)})))

--- a/src/cljs/wish/push.cljs
+++ b/src/cljs/wish/push.cljs
@@ -1,20 +1,51 @@
 (ns ^{:author "Daniel Leong"
       :doc "Push-notification API"}
   wish.push
-  (:require [wish.config :as config]
+  (:require-macros [cljs.core.async :refer [go]]
+                   [wish.util.log :refer [log] :as log])
+  (:require [clojure.core.async :refer [<!]]
+            [wish.config :as config]
             [wish.providers :as providers]
+            [wish.sheets.util :refer [unpack-id]]
+            [wish.util :refer [>evt]]
             [wish.util.http :refer [POST]]))
 
 (def push-server-version "v1")
 
-(def ^:private push-url-base (str config/push-server "/" push-server-version))
+(def ^:private push-url-base (str config/push-server "/" push-server-version "/push"))
+
+(defn session-args [auth interested-ids]
+  {:auth auth
+
+   :ids (->> interested-ids
+
+             ; remove sheet ids for which we don't have auth
+             (filter (fn [sheet-id]
+                       (let [[provider-id _] (unpack-id sheet-id)]
+                         (contains? auth provider-id))))
+
+             ; default serialization of a keyword drops the namespace
+             (map (fn [id]
+                    (subs (str id) 1))))})
+
+(defn- do-create-session [auth interested-ids]
+  (POST (str push-url-base "/sessions")
+        (session-args auth interested-ids)))
 
 (defn create-session [interested-ids]
   (when-let [auth (providers/watch-auth-map interested-ids)]
-    (POST (str push-url-base "/push/sessions")
-          {:auth auth
+    (go (when-let [[err {:keys [id]}] (<! (do-create-session auth interested-ids))]
+          (if err
+            (log/warn "Unable to create push session" err)
+            (>evt [::session-created interested-ids id]))))))
 
-           ; default serialization of a keyword drops the namespace
-           :ids (map (fn [id]
-                       (subs (str id) 1))
-                     interested-ids)})))
+(defn connect [session-id]
+  (log "Connecting to session " session-id)
+  (doto (js/EventSource.
+          (str push-url-base "/sessions/" session-id))
+    (.addEventListener "error" (fn [e]
+                                 (log/warn "Error with push session" e)))
+    (.addEventListener "open" (fn []
+                                (log/info "Connected to session " session-id)))
+    (.addEventListener "message" (fn [evt]
+                                   (log/info "Pushed: " evt (.-data evt))))))

--- a/src/cljs/wish/subs.cljs
+++ b/src/cljs/wish/subs.cljs
@@ -667,6 +667,13 @@
   :interested-push-ids
   :<- [:active-sheet-id]
   :<- [:active-sheet-source-ids]
-  (fn [[sheet-id source-ids] _]
-    (when sheet-id
+  :<- [:my-sheets]
+  (fn [[sheet-id source-ids my-sheets] _]
+    ; NOTE: currently, we're only interested in changes
+    ; to sheets we *don't* own.
+    ; We could later listen to changes in the sources for
+    ; a sheet we own, in which case we wouldn't be interested
+    ; in sheet-id
+    (when (and sheet-id
+               (not (contains? my-sheets sheet-id)))
       (into #{sheet-id} source-ids))))

--- a/src/cljs/wish/subs.cljs
+++ b/src/cljs/wish/subs.cljs
@@ -659,3 +659,14 @@
 
       ; otherwise, idle
       :else :idle)))
+
+
+; ======= Push notifications ==============================
+
+(reg-sub
+  :interested-push-ids
+  :<- [:active-sheet-id]
+  :<- [:active-sheet-source-ids]
+  (fn [[sheet-id source-ids] _]
+    (when sheet-id
+      (into #{sheet-id} source-ids))))

--- a/src/cljs/wish/util/http.cljs
+++ b/src/cljs/wish/util/http.cljs
@@ -1,0 +1,38 @@
+(ns ^{:author "Daniel Leong"
+      :doc "core.async http wrapper"}
+  wish.util.http
+  (:require-macros [wish.util.log :refer [log]])
+  (:require [clojure.core.async :refer [chan put! to-chan <! >!]]
+            [ajax.core :as ajax]))
+
+(defn GET
+  ([url]
+   (GET url nil))
+
+  ([url {:keys [response-format]}]
+   (let [ch (chan 1)]
+     (ajax/GET url
+               {:handler (fn [raw]
+                           (put! ch [nil raw]))
+                :response-format (or response-format :json)
+                :keywords? true
+                :error-handler (fn [e]
+                                 (put! ch [e]))})
+     ch)))
+
+(defn POST
+  ([url body]
+   (POST url body nil))
+
+  ([url body {:keys [response-format]}]
+   (let [ch (chan 1)]
+     (ajax/POST url
+                {:handler (fn [raw]
+                            (put! ch [nil raw]))
+                 :response-format (or response-format :json)
+                 :keywords? true
+                 :params body
+                 :format :json
+                 :error-handler (fn [e]
+                                  (put! ch [e]))})
+     ch)))

--- a/src/cljs/wish/util/throttled_set.cljs
+++ b/src/cljs/wish/util/throttled_set.cljs
@@ -1,0 +1,71 @@
+(ns ^{:author "Daniel Leong"
+      :doc "Fn throttling based on a changing set"}
+  wish.util.throttled-set
+  (:require [clojure.set :refer [subset?]]))
+
+(def ^:private initial-state {:timer nil
+                              :args nil
+                              :entries #{}})
+
+(defn throttle-with-set
+  "Returns a fn that accepts a set entry or collection of
+   set entries and eventually calls `f` with the set of all
+   entries passed to that fn. `f` is not called until the
+   returned fn has not been called for `delay-ms` milliseconds.
+
+   The returned fn also accepts N extra arguments. If any of
+   these change between invocations, the previous state is
+   submitted immediately. Any such extra arguments will be
+   passed as with (apply) after the set of entries."
+  [delay-ms f]
+  (let [state (atom initial-state)
+        call-f (fn f-caller []
+                 (swap! state
+                        (fn [{:keys [entries args]}]
+                          (if args
+                            (apply f entries args)
+                            (f entries))
+
+                          ; reset state:
+                          initial-state)))
+        defer-f #(js/setTimeout
+                   call-f
+                   delay-ms)]
+
+    (fn throttled-fn [input & new-args]
+      (let [input-set (if (coll? input)
+                        (set input)
+                        #{input})
+            new-args (seq new-args)]
+        (swap! state
+               (fn [{:keys [timer entries args] :as old-state}]
+                 (cond
+                   ; new args?
+                   (and timer (not= args new-args))
+                   (do
+                     (when timer
+                       (js/clearTimeout timer))
+
+                     ; submit any old state immediately...
+                     (if args
+                       (apply f entries args)
+                       (f entries))
+
+                     ; ... and defer new state
+                     {:entries input-set
+                      :args new-args
+                      :timer (defer-f)})
+
+                   ; nothing new? ignore
+                   (subset? input-set entries)
+                   old-state
+
+                   ; new entries; cancel any old timer and start a
+                   ; new one, including new entries in the pending set
+                   :else
+                   (do
+                     (when timer
+                       (js/clearTimeout timer))
+                     {:entries (into entries input-set)
+                      :args new-args
+                      :timer (defer-f)}))))))))

--- a/test/cljs/wish/push_test.cljs
+++ b/test/cljs/wish/push_test.cljs
@@ -1,0 +1,21 @@
+(ns wish.push-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [wish.push :refer [session-args]]))
+
+(deftest session-args-test
+  (testing "Properly serializes sheet ids"
+    (is (= "[\"gdrive/wid\"]"
+           (js/JSON.stringify
+             (clj->js
+               (:ids
+                 (session-args
+                   {:gdrive "let-me-in"}
+                   #{:gdrive/wid})))))))
+
+  (testing "Removes ids with no provider auth"
+    (is (= ["gdrive/wid"]
+           (:ids
+             (session-args
+               {:gdrive "let-me-in"}
+               [:gdrive/wid :wish/wid]))))))
+

--- a/test/cljs/wish/runner.cljs
+++ b/test/cljs/wish/runner.cljs
@@ -2,6 +2,7 @@
   (:require [doo.runner :refer-macros [doo-tests doo-all-tests]]
             [wish.events-test]
             [wish.inventory-test]
+            [wish.push-test]
             [wish.providers.gdrive.api-test]
             [wish.sheets.dnd5e.builder-test]
             [wish.sheets.dnd5e.data-test]


### PR DESCRIPTION
See: https://github.com/dhleong/wish-server

This PR implements the core protocol with support for `change` notifications (and the `need-watch` event, of course). Currently, we only subscribe to a session for sheets we do not own; since nobody can yet change our sheet (we don't request the GDrive scope) there's no need to listen to changes to our own sheet. 

In the future, we probably want to listen for changes to DataSources, but we don't handle such changes yet. 

This channel will, in the future, allow DMs to *suggest* changes to player sheets, such as granting custom items, etc. See #69 

Closes #53 