### PR TITLE
Fancier special actions

### DIFF
--- a/docs/dnd5e/DnD Attrs.md
+++ b/docs/dnd5e/DnD Attrs.md
@@ -331,6 +331,20 @@ Sneak Attack. Sneak Attack does not consume any time on its own, but is
 used in conjunction with an action.
 See [`:action`](#action) above for format and usage.
 
+Instead of the normal `true` value, you can also provide special flags as
+a map, for example `{:combat true}`, or, for a single flag, use the shortcut
+of suppling the flag directly, eg:
+
+```clojure
+[:!provide-attr
+ [:special-action :paladin/divine-smite]
+ :combat]
+```
+
+Supported flags:
+
+- `:combat` The action will be displayed on the "Combat" section of the "Actions" page. This is useful for things like Divine Smite or Sneak Attack that add to the damage dealt by a normal attack.
+
 ## `:spells`
 
 Modify the attributes of a spell. Very commonly used by Warlock Eldritch Invocations, but might also be used by racial traits.

--- a/resources/sources/dnd5e/classes/paladin.edn
+++ b/resources/sources/dnd5e/classes/paladin.edn
@@ -105,9 +105,13 @@ This feature has no effect on undead and constructs."
                  :desc "Starting at 2nd level, when you hit a creature with a melee weapon attack, you can expend one spell slot to deal radiant damage to the target, in addition to the weapon’s damage. The extra damage is 2d8 for a 1st-level spell slot, plus 1d8 for each spell level higher than 1st, to a maximum of 5d8. The damage increases by 1d8 if the target is an undead or a fiend."
                  :spell-level 1 ; min spell slot level
                  :consumes :*spell-slot
+                 :damage :radiant
+                 :dice (fn [spell-level]
+                         (str (min 5 (+ 1 spell-level))
+                              "d8"))
                  :! [[:!provide-attr
                       [:special-action :paladin/divine-smite]
-                      true]]} ]}
+                      :combat]]} ]}
 
             3 {:+features
                [{:id :paladin/divine-health

--- a/resources/sources/dnd5e/classes/rogue.edn
+++ b/resources/sources/dnd5e/classes/rogue.edn
@@ -86,7 +86,7 @@ The amount of the extra damage increases as you gain levels in this class, as sh
              20 {:>>desc "\nAt 20th level, your sneak attack damage is **10d6**"}}
     :! [[:!provide-attr
          [:special-action :rogue/sneak-attack]
-         true]
+         :combat]
         [:!provide-attr
          [:combat-info :rogue/sneak-attack]
          {:name "Sneak Attack Damage"

--- a/src/cljs/wish/sheets/dnd5e.cljs
+++ b/src/cljs/wish/sheets/dnd5e.cljs
@@ -620,7 +620,7 @@
         level (or cast-level base-level)]
     [expandable
      [:div.spell
-      [cast-button s]
+      [cast-button {:nested? true} s]
 
       [:div.spell-info
        [:div.name (:name s)]

--- a/src/cljs/wish/sheets/dnd5e.cljs
+++ b/src/cljs/wish/sheets/dnd5e.cljs
@@ -384,7 +384,17 @@
       [:h4 "Other Attacks"]
       (for [a attacks]
         ^{:key (:id a)}
-        [attack-block a])])])
+        [attack-block a])])
+
+   (when-let [actions (seq (<sub [::subs/special-combat-actions]))]
+     [:div.special
+      [:h4 "Special Attack Actions"]
+      (for [a actions]
+        ^{:key (:id a)}
+        [:div.clickable
+         {:on-click (click>evt [:toggle-overlay [#'overlays/info a]])}
+         (:name a)])])
+   ])
 
 (defn- action-block
   [a]
@@ -404,7 +414,7 @@
 
 (defn- actions-for-type [filter-type]
   (let [spells (seq (<sub [::subs/prepared-spells-filtered filter-type]))
-        actions (seq (<sub [::subs/combat-actions filter-type]))]
+        actions (seq (<sub [::subs/actions-for-type filter-type]))]
     (if (or spells actions)
       [:<>
        (when spells

--- a/src/cljs/wish/sheets/dnd5e/style.cljs
+++ b/src/cljs/wish/sheets/dnd5e/style.cljs
@@ -430,6 +430,8 @@
           :margin "0 8px 0 0"})
   [:&.upcast {:position 'relative
               :border (str "2px solid " color-accent2)}
+   [:&:hover {:background-color "#f0f0f0"
+              :color "#333"}]
    [:&:hover>.upcast-level
     {:background (color/lighten color-accent2 20)}]
    [:.upcast-level {:position 'absolute
@@ -441,14 +443,16 @@
                     :bottom "-0.7em"
                     :font-size "0.5em"
                     :transform "translate(50%, 0)"}]]
+  [:.uses-remaining {:padding "0.1em"
+                     :font-size "0.7em"
+                     :font-style 'italic}]
 
   [:&.button
    [:&.disabled {:font-style 'italic
                  :color "rgba(1,1,1, 0.25) !important"
                  :cursor 'default} ]
-   [:&:hover {:background-color "#f0f0f0"
-              :color "#333"}
-    [:&.disabled {:background-color "#ccc"}]]])
+   [:&.nested:hover {:background-color "#f0f0f0"
+                     :color "#333"}]])
 
 (defstyled spell-card
   {:max-width "300px"}


### PR DESCRIPTION
Divine Smite is a particularly annoying special action to use, since it consumes spell slots but is used as part of a melee weapon attack: you have to be able to reference your weapon damage, check how many dice you get to add for the smite, and also consume the spell slot when you hit. 

With the previous design, in the "best" case—where you want to use the lowest-level spell slot available to smite—this only involved two pages under the Actions section: Combat and Other. In the "worst" case, where you want to use a higher-level slot—and, let's be honest, that's much more fun—you have to go to the Spell page as a third step to manually remove the slot. Now, if you've memorized exactly how many dice and of which kind then this isn't *terrible* UX, but if you're like me and constantly want to double check things anyway then it's quite frustrating.

With this PR, special actions can be surfaced on the Combat page so you can tap on them to view the full information, and Divine Smite has been updated with more spell-like info, so you can "upcast" it and see exactly how many dice you get to add right there. It's not inline, exactly, but you don't have to think about which section it's in—it's all just next to your weapon attack stuff, where you'd expect it.