### PR TITLE
Allow consuming limited-use features from the Features section

### DIFF
--- a/src/cljs/wish/sheets/dnd5e.cljs
+++ b/src/cljs/wish/sheets/dnd5e.cljs
@@ -396,20 +396,26 @@
          (:name a)])])
    ])
 
-(defn- action-block
-  [a]
+(defn- consume-use-block
+  [consumable {:keys [omit-name]}]
+  (when-let [use-id (:consumes consumable)]
+    (when-let [{:keys [name uses-left] :as info}
+               (<sub [::subs/consumable consumable])]
+      [:div styles/consumable-use-block
+
+       (when (not= name omit-name)
+         [:div.name name])
+
+       [:div.uses uses-left " left"]
+       (when (> uses-left 0)
+         [:div.button
+          {:on-click (click>evt [::events/+use info 1])}
+          "Use 1"])])))
+
+(defn- action-block [a]
   [:div.action
    [:div.name (:name a)]
-   (when-let [use-id (:consumes a)]
-     (when-let [{:keys [name uses-left] :as info}
-                (<sub [::subs/consumable a])]
-       [:div.consumable
-        [:div.name name]
-        [:div.uses uses-left " left"]
-        (when (> uses-left 0)
-          [:div.button
-           {:on-click (click>evt [::events/+use info 1])}
-           "Use 1"])]))
+   [consume-use-block a]
    [formatted-text :div.desc (:desc a)]])
 
 (defn- actions-for-type [filter-type]
@@ -487,11 +493,8 @@
   (let [values (seq (:values f))]
     [:div.feature
      [:div.name (:name f)]
-     ;; (when values
-     ;;   [:div.chosen (->> values
-     ;;                     (take 4)
-     ;;                     (map :name)
-     ;;                     (str/join " · "))])
+
+     [consume-use-block f {:omit-name (:name f)}]
 
      [formatted-text :div.desc (:desc f)]
 

--- a/src/cljs/wish/sheets/dnd5e.cljs
+++ b/src/cljs/wish/sheets/dnd5e.cljs
@@ -401,16 +401,26 @@
   (when-let [use-id (:consumes consumable)]
     (when-let [{:keys [name uses-left] :as info}
                (<sub [::subs/consumable consumable])]
-      [:div styles/consumable-use-block
+      (if (= :*spell-slot use-id)
+        ; consuming spell slots is a special case
+        [:div styles/consumable-use-block
+         (if (<= uses-left 0)
+           [:div.uses "0 spell slots left"]
+           [:div.button
+            {:on-click (click>evt [:toggle-overlay [#'overlays/info consumable]])}
+            (str uses-left " spell slots left")])]
 
-       (when (not= name omit-name)
-         [:div.name name])
+        ; normal case:
+        [:div styles/consumable-use-block
 
-       [:div.uses uses-left " left"]
-       (when (> uses-left 0)
-         [:div.button
-          {:on-click (click>evt [::events/+use info 1])}
-          "Use 1"])])))
+         (when (not= name omit-name)
+           [:div.name name])
+
+         [:div.uses uses-left " left"]
+         (when (> uses-left 0)
+           [:div.button
+            {:on-click (click>evt [::events/+use info 1])}
+            "Use 1"])]))))
 
 (defn- action-block [a]
   [:div.action

--- a/src/cljs/wish/sheets/dnd5e/style.cljs
+++ b/src/cljs/wish/sheets/dnd5e/style.cljs
@@ -494,6 +494,14 @@
 (defstyled swipeable-page
   {:min-height "60vh"})
 
+(defstyled consumable-use-block
+  (merge flex/center
+         {:font-size "80%"
+          :margin-bottom "1em"
+          :padding "8px 8px 0 8px"})
+
+  [:.uses {:padding "4px"}])
+
 ;;
 ;; Sections
 ;;
@@ -584,11 +592,6 @@
    [:.name {:font-size "90%"
             :font-weight 'bold
             :font-style 'italic}]
-   [:.consumable (merge flex/center
-                        {:font-size "80%"
-                         :margin-bottom 0
-                         :padding "8px 8px 0 8px"})
-    [:.uses {:padding "4px"}]]
    [:.desc metadata]])
 
 (def single-column-skills [:.base-ability


### PR DESCRIPTION
Also improves the (now shared) `consume-use-block` for things that consume spell slots, opening the "info" overlay which allows you to pick the spell slot and see any associated changes to dice rolls.