### PR TITLE
Simplify the Actions page

### DIFF
--- a/src/cljs/wish/sheets/dnd5e.cljs
+++ b/src/cljs/wish/sheets/dnd5e.cljs
@@ -503,8 +503,7 @@
    (if selected?
      [:span.unselectable label]
 
-     [; link>evt [::events/actions-page! id]
-      :a {:href "#"
+     [:a {:href "#"
           :on-click (fn-click
                       (let [el (get-in @state [:elements id])]
                         (scroll-into-view el)))}

--- a/src/cljs/wish/sheets/dnd5e/style.cljs
+++ b/src/cljs/wish/sheets/dnd5e/style.cljs
@@ -556,14 +556,17 @@
   [:.extras metadata])
 
 (defstyled actions-section
+  (at-media media-smartphones
+            [:.filters {:justify-content 'center}])
   [:.filters (merge flex
                     {:border-bottom "1px solid #333"
                      :margin-bottom "8px"
-                     :overflow-x 'auto})
+                     :overflow-x 'hidden})
    ["&:not(:first-child)"
     {:margin-top "32px"}]
    [:.filter {:padding "4px"}
-    [:a {:font-size "80%"}]]]
+    [:.unselectable {:font-weight 'bold}]
+    [:a {:font-size "75%"}]]]
 
   [:.combat-info (merge metadata
                         {:margin-bottom "8px"})

--- a/src/cljs/wish/sheets/dnd5e/style.cljs
+++ b/src/cljs/wish/sheets/dnd5e/style.cljs
@@ -560,7 +560,10 @@
                     {:border-bottom "1px solid #333"
                      :margin-bottom "8px"
                      :overflow-x 'auto})
-   [:.filter {:padding "4px"}]]
+   ["&:not(:first-child)"
+    {:margin-top "32px"}]
+   [:.filter {:padding "4px"}
+    [:a {:font-size "80%"}]]]
 
   [:.combat-info (merge metadata
                         {:margin-bottom "8px"})

--- a/src/cljs/wish/util/scroll.cljs
+++ b/src/cljs/wish/util/scroll.cljs
@@ -1,0 +1,21 @@
+(ns ^{:author "Daniel Leong"
+      :doc "Scroll utils"}
+  wish.util.scroll)
+
+(defn find-scroll-parent [el]
+  (when el
+    (let [client-height (.-clientHeight el)]
+      (if (and (not= 0 client-height)
+               (> (.-scrollHeight el) client-height))
+        el
+
+        (recur (.-parentElement el))))))
+
+(defn scrolled-amount [el]
+  (let [scrolling (when-let [scrolling-el js/document.scrollingElement]
+                    (.-scrollTop scrolling-el))]
+    (if (> scrolling 0)
+      scrolling
+
+      (when-let [parent (find-scroll-parent el)]
+        (.-scrollTop parent)))))

--- a/src/cljs/wish/views/widgets/swipeable.cljs
+++ b/src/cljs/wish/views/widgets/swipeable.cljs
@@ -14,7 +14,18 @@
        (map-indexed list)
        (reduce
          (fn [m [index c]]
-           (assoc m (-> c meta :key) index))
+           (assoc m (or
+                      ; easy case:
+                      (-> c meta :key)
+
+                      ; common case:
+                      (when (and (vector? c)
+                                 (> (count c) 2))
+                        (:key (get c 1)))
+
+                      ; warn!
+                      (js/console.warn "NO KEY on [swipeable] child: " c))
+                  index))
          {})))
 
 (defn- unpack-key-ops


### PR DESCRIPTION
Closes #119 

This PR reorganizes the Actions tab into a single, vertically scrolling page. The existing subtabs have been kept functionally, but flow vertically, and each have their own header with quick jump links to the other sections in the page. 

Furthermore, we remove the old "jump to the top" behavior when changing tabs, opting for a less invasive "jump to make visible" *as necessary*, instead of just always doing it. 

I think this will be *much* nicer to use, and since I've recently been using my laptop for the video call and my phone for my sheet, I can't wait to use it.