### PR TITLE
5e Experiment: fix nested button activation by fake nesting

### DIFF
--- a/src/cljs/wish/sheets/dnd5e/style.cljs
+++ b/src/cljs/wish/sheets/dnd5e/style.cljs
@@ -148,16 +148,20 @@
 
   [:&.button
    [:&.disabled disabled-button]
-   [:&.nested:hover {:background-color "#f0f0f0"
-                     :color "#333"}
-    (at-media media/dark-scheme
-      {:background-color "#777"
-       :color theme/text-primary-on-dark})]
-   [:&.nested:active {:background-color "#f0f0f0"
-                     :color "#333"}
-    (at-media media/dark-scheme
-      {:background-color "#222"
-       :color theme/text-primary-on-dark})]])
+   [:&.placeholder {:visibility 'hidden}]
+   [:&.nested {:position 'absolute
+               :margin-top "8px"
+               :margin-left "16px"}
+    [:&:hover {:background-color "#f0f0f0"
+                      :color "#333"}
+     (at-media media/dark-scheme
+       {:background-color "#777"
+        :color theme/text-primary-on-dark})]
+    [:&:active {:background-color "#f0f0f0"
+                       :color "#333"}
+     (at-media media/dark-scheme
+       {:background-color "#222"
+        :color theme/text-primary-on-dark})]]])
 
 (defattrs spell-card []
   {:max-width "300px"}

--- a/src/cljs/wish/sheets/dnd5e/style.cljs
+++ b/src/cljs/wish/sheets/dnd5e/style.cljs
@@ -152,16 +152,10 @@
    [:&.nested {:position 'absolute
                :margin-top "8px"
                :margin-left "16px"}
-    [:&:hover {:background-color "#f0f0f0"
-                      :color "#333"}
-     (at-media media/dark-scheme
-       {:background-color "#777"
-        :color theme/text-primary-on-dark})]
-    [:&:active {:background-color "#f0f0f0"
-                       :color "#333"}
-     (at-media media/dark-scheme
-       {:background-color "#222"
-        :color theme/text-primary-on-dark})]]])
+    ; make the bg transparent so highlights for the parent element
+    ; come through cleanly (unless we're being pressed/hovered)
+    ["&:not(:hover):not(:active)"
+     {:background-color "rgba(0,0,0,0)"}]]])
 
 (defattrs spell-card []
   {:max-width "300px"}

--- a/src/cljs/wish/sheets/dnd5e/views/spells.cljs
+++ b/src/cljs/wish/sheets/dnd5e/views/spells.cljs
@@ -14,49 +14,50 @@
 
 ; ======= Spells ===========================================
 
-(defn spell-block
-  [s]
+(defn spell-block [s]
   (let [base-level (:spell-level s)
         cantrip? (= 0 base-level)
         {cast-level :level} (<sub [::spells/usable-slot-for s])
         upcast? (when cast-level
                   (not= cast-level base-level))
         level (or cast-level base-level)]
-    [expandable
-     [:div.spell
-      [cast-button {:nested? true} s]
+    [:<>
+     [cast-button {:nested? true} s]
+     [expandable
+      [:div.spell
+       [cast-button {:placeholder? true} s]
 
-      [:div.spell-info
-       [:div.name (:name s)]
+       [:div.spell-info
+        [:div.name (:name s)]
 
-       [:div.meta {:class (when upcast?
-                            "upcast")}
-        (if cantrip?
-          "Cantrip"
-          (str "Level " level))
-        ; concentration? ritual?
-        [spell-tags s]]]
-
-      (cond
-        (:dice s)
-        [:div.dice {:class (when upcast?
+        [:div.meta {:class (when upcast?
                              "upcast")}
-         (invoke-callable
-           (assoc s :spell-level level)
-           :dice)
-         (when-let [buffs (:buffs s)]
-           (when-let [buff (buffs s)]
-             (str " + " buff)))
-         ]
+         (if cantrip?
+           "Cantrip"
+           (str "Level " level))
+         ; concentration? ritual?
+         [spell-tags s]]]
 
-        (:save s)
-        [:div.dice
-         [:div.meta (:save-label s)]
-         (:save-dc s)]
-        )]
+       (cond
+         (:dice s)
+         [:div.dice {:class (when upcast?
+                              "upcast")}
+          (invoke-callable
+            (assoc s :spell-level level)
+            :dice)
+          (when-let [buffs (:buffs s)]
+            (when-let [buff (buffs s)]
+              (str " + " buff)))
+          ]
 
-     ; collapsed:
-     [spell-card s]]))
+         (:save s)
+         [:div.dice
+          [:div.meta (:save-label s)]
+          (:save-dc s)]
+         )]
+
+      ; collapsed:
+      [spell-card s]]]))
 
 (defn spell-slot-use-block
   [kind level total used]
@@ -66,7 +67,7 @@
     :consume-evt [::events/use-spell-slot kind level total]
     :restore-evt [::events/restore-spell-slot kind level total]}])
 
-(defn spells-list [spells]
+(defn- spells-list [spells]
   [:<>
    (for [s spells]
      ^{:key (:id s)}

--- a/src/cljs/wish/sheets/dnd5e/widgets.cljs
+++ b/src/cljs/wish/sheets/dnd5e/widgets.cljs
@@ -113,7 +113,7 @@
   "Renders a button to cast the given spell at its current level.
    Renders a box with 'At Will' if the spell is a cantrip"
   ([s] (cast-button nil s))
-  ([{:keys [base-level upcastable? nested?]
+  ([{:keys [base-level upcastable? nested? placeholder?]
      :or {upcastable? true}} s]
    (let [cantrip? (= 0 (:spell-level s))
          at-will? (or cantrip?
@@ -162,17 +162,17 @@
 
      (if at-will?
        ; easy case; at-will spells don't need a "cast" button
-       [:div.cast {:class (styles/cast-spell)}
-        "At Will"]
+       ; in fact, when nested we don't need to render anything
+       (when-not nested?
+         [:div.cast {:class [(styles/cast-spell)]}
+          "At Will"])
 
        [:div.cast.button
         {:class [(styles/cast-spell)
-                 (when nested?
-                   "nested")
-                 (when-not has-uses?
-                   "disabled")
-                 (when upcast?
-                   "upcast")]
+                 (when nested? :nested)
+                 (when-not has-uses? :disabled)
+                 (when upcast? :upcast)
+                 (when placeholder? :placeholder)]
          :on-click (fn-click [e]
                      (when has-uses?
                        (.stopPropagation e)


### PR DESCRIPTION
Currently, when the "Cast" button is pressed on the header of a spell,
because that button is nested within the button header for the spell
both elements get the :active state, which looks a bit weird.

This change solves that by instead rendering the Cast button as an
absolutely-positioned sibling, while also rendering the same button
as a nested child, but invisible, to keep the spacing as expected.

This might be a terrible idea.
