### PR TITLE
Improved Builder UI

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -268,38 +268,6 @@ div.p {
     }
 }
 
-.builder {
-    .header {
-        .align-items(center);
-
-        .section-link {
-            padding: 8px;
-        }
-    }
-
-    .refresh-button {
-        display: inline;
-
-        i.material-icons {
-            font-size: 16pt;
-            vertical-align: middle;
-        }
-
-        .invisible {
-            visibility: hidden;
-        }
-    }
-
-    .builder-main {
-        width: 600px;
-    }
-
-    .section-arrow {
-        .align-self(center);
-        padding: 16px;
-    }
-}
-
 .class-section {
     padding-bottom: 3em;
 }

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -266,22 +266,27 @@
                   :doc #(<sub [:meta/options])}
 
              max-options (count-max-options f extra-info)
-             selected-count (count (get-option [instance-id]))]
+             selected-count (count (get-option [instance-id]))
+
+             ; special cases: (should we have a flag on the feature?)
+             count-options (not= :feats feature-id)]
 
          ^{:key instance-id}
          [:div.feature {:class (when (> (count (:wish/sort f)) 2)
                                  "provided")}
           [:h3.title
-           [selected-option-counter
-            selected-count
-            max-options]
+           (when count-options
+             [selected-option-counter
+              selected-count
+              max-options])
 
            (:name f)
 
            (when-let [n (:wish/instance f)]
              (str " #" (inc n)))]
 
-          (when (< selected-count max-options)
+          (when (and count-options
+                     (< selected-count max-options))
             [:div.content>div.selected-count
              "Selected " selected-count " / " max-options])
 

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -14,6 +14,7 @@
             [wish.sheets.dnd5e.subs.hp :as hp]
             [wish.sheets.dnd5e.events :as events]
             [wish.sheets.dnd5e.util :refer [mod->str]]
+            [wish.style.media :as media]
             [wish.util :refer [<sub >evt click>reset! click>swap!]]
             [wish.style.flex :as flex :refer [flex]]
             [wish.style.shared :as style]
@@ -576,6 +577,11 @@
                (mod->str b)
                "—")])]]))
 
+(defattrs ability-label [label]
+  [:&:after {:content (str "'" label "'")}]
+  (at-media media/smartphones
+    [:&:after {:content (str "'" (subs label 0 3) "'")}]))
+
 (defn abilities-page []
   (let [mode (<sub [::builder/abilities-mode])]
     [:div (abilities-style)
@@ -607,7 +613,7 @@
        [:tr
         (for [[id label] labeled-abilities]
           ^{:key id}
-          [:th label])]
+          [:th (ability-label label)])]
 
        ; see comment on the definition of these vars above
        (case mode

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -656,16 +656,28 @@
 
 ; ======= router ===========================================
 
+(defattrs icon-nav-attrs []
+  {:padding "0 8px"})
+
+(defn icon-nav [ico]
+  [:div (icon-nav-attrs)
+   ico])
+
 (def pages
-  [[:home {:name "Home"
+  [[:home {:name "Config"
+           :icon [icon-nav (icon :app-settings-alt)]
            :fn #'home-page}]
    [:race {:name "Race"
+           :icon [icon-nav (icon :emoji-people)]
            :fn #'race-page}]
    [:abilities {:name "Abilities"
+                :icon [icon-nav (icon :school)]
                 :fn #'abilities-page}]
    [:background {:name "Background"
+                 :icon [icon-nav (icon :history-edu)]
                  :fn #'background-page}]
    [:class {:name "Level Up"
+            :icon [icon-nav (icon :plus-one)]
             :fn #'classes-page}]])
 
 (defn view

--- a/src/cljs/wish/style/util.cljs
+++ b/src/cljs/wish/style/util.cljs
@@ -1,0 +1,4 @@
+(ns wish.style.util
+  (:require [garden.stylesheet :refer [cssfn]]))
+
+(def linear-gradient (cssfn "linear-gradient"))

--- a/src/cljs/wish/views/sheet_builder_util.cljs
+++ b/src/cljs/wish/views/sheet_builder_util.cljs
@@ -31,9 +31,23 @@
    (or (when (number? max-options)
          max-options)
 
+       ; if the fn returns a number, we can use that
        (when-let [n (max-options extra-info)]
          (when (number? n)
            n))
+
+       ; perhaps it expects a set of features?
+       ; I'm not sure if we ever used this, but...
+       (first
+         (keep
+           (fn [to-take]
+             (when-not (max-options
+                         (merge
+                           extra-info
+                           {:features
+                            (take to-take values)}))
+               (dec to-take)))
+           (range 1 (inc (count values)))))
 
        ;; fallback, I guess?
        (count values))))

--- a/src/cljs/wish/views/sheet_builder_util.cljs
+++ b/src/cljs/wish/views/sheet_builder_util.cljs
@@ -3,24 +3,28 @@
   wish.views.sheet-builder-util
   (:require-macros [wish.util :refer [fn-click]])
   (:require [reagent.core :as r]
+            [spade.core :refer [defattrs defclass]]
             [wish.util :refer [<sub >evt click>evt]]
             [wish.util.nav :refer [sheet-url]]
             [wish.providers :as providers]
+            [wish.style.media :as media]
+            [wish.style.util :refer [linear-gradient]]
             [wish.views.widgets :refer [link link>evt save-state] :refer-macros [icon]]))
 
-(defn- find-section
-  [candidates target-id]
-  (reduce-kv
-    (fn [_ i [id info]]
-      (when (= id target-id)
-        (reduced
-          [i id info])))
-    nil
-    candidates))
+(defclass sections-class []
+  {:display 'flex
+   :flex-wrap [['wrap :!important]]
+   :justify-content 'center}
+
+  [:&.spread {:width "100%"
+              :justify-content 'space-between}]
+  [:.section {:width "400px"
+              :margin "8px"}])
+
+; ======= util ============================================
 
 (defn count-max-options
-  ([feature]
-   (count-max-options feature nil))
+  ([feature] (count-max-options feature nil))
   ([{values :values
      accepted? :max-options}
     extra-info]
@@ -41,6 +45,51 @@
        ;; fallback, I guess?
        (count values))))
 
+
+; ======= builder section routing =========================
+
+(defattrs builder-attrs []
+  [:.header {:display 'flex
+             :flex-direction 'column
+             :align-items 'center
+             :padding-bottom "1em"}
+   [:&.sticky {:position 'sticky
+               :top 0
+               :background (linear-gradient
+                             :180deg
+                             ["#fff" :50%]
+                             ["rgba(255,255,255,0)" :100%])}
+    (at-media media/dark-scheme
+     {:background (linear-gradient
+                    :180deg
+                    ["#000" :50%]
+                    ["rgba(0,0,0,0)" :100%])})]]
+
+  [:.builder-main {:width "600px"}]
+  [:.section-arrow {:padding "4px 8px"}
+   [:&.prev {:margin-right "8px"}]
+   [:&.empty {:visibility 'hidden}]])
+
+(defattrs header-row [& sticky?]
+  {:composes (sections-class)
+   :align-items 'center
+
+   :position (when sticky?
+               'sticky)
+   :top 0
+   })
+
+(defn- find-section
+  [candidates target-id]
+  (reduce-kv
+    (fn [_ i [id info]]
+      (when (= id target-id)
+        (reduced
+          [i id info])))
+    nil
+    candidates))
+
+
 (defn router
   "Sections should be a vector of [id {:name, :fn}] pairs,
    in the order in which they should appear"
@@ -52,42 +101,50 @@
         next-sec (when (< index (dec (count sections)))
                    (nth sections (inc index)))]
     (println "[builder-router] " sheet-id " / " current-section)
-    [:div.builder
-     [:div.header.sections
-      (for [[id info] sections]
-        ^{:key id}
-        [:div.section-link
-         {:class (when (= id current-section)
-                   "selected")}
-         [link {:href (sheet-url sheet-id :builder id)}
-          (:name info)]])
+    [:div (builder-attrs)
+     [:div.header
+      [:div (header-row)
+       (for [[id info] sections]
+         ^{:key id}
+         [:div.section-link
+          {:class (when (= id current-section)
+                    "selected")}
+          [link {:href (sheet-url sheet-id :builder id)}
+           (:name info)]])]]
 
-      [save-state]
+     [:div.sticky.header
+      [:div (header-row)
+       [:div.section-arrow.prev {:class (when-not prev-sec
+                                          :empty)}
+        (if-let [[prev-id _] prev-sec]
+          [link {:href (sheet-url sheet-id :builder prev-id)}
+           (icon :arrow-back)]
 
-      [link {:href (sheet-url sheet-id)}
-       (icon :description)]
+          [:div.nav-link
+           (icon :arrow-back)])]
 
-      ]
+       [save-state]
 
-     [:div.sections
-      [:div.section-arrow.prev
-       (when-let [[prev-id prev-info] prev-sec]
-         [link {:href (sheet-url sheet-id :builder prev-id)}
-          (:name prev-info)])]
+       [link {:href (sheet-url sheet-id)}
+        (icon :description)]
 
+       [:div.section-arrow.next
+        (if-let [[next-id _] next-sec]
+          [link {:href (sheet-url sheet-id :builder next-id)}
+           (icon :arrow-forward)]
+          [link {:href (sheet-url sheet-id)}
+           (icon :check)])]
+       ]]
+
+     [:div {:class (sections-class)}
       [:div.builder-main
        (if section-info
          [(:fn section-info)]
          [:div.error "Unknown section " current-section])]
+      ]]))
 
-      [:div.section-arrow.next
-       (if-let [[next-id next-info] next-sec]
-         [link {:href (sheet-url sheet-id :builder next-id)}
-          (:name next-info)]
 
-         ; TODO probably, only show if the sheet is "ready" to use
-         [link {:href (sheet-url sheet-id)}
-          "Let's play!"])]]]))
+; ======= campaign management =============================
 
 (defn campaign-manager []
   (when-let [campaign-info (<sub [:meta/campaign])]
@@ -123,11 +180,20 @@
            "Click here if you want to leave this campaign."]
           ])])))
 
+
+; ======= data source management ==========================
+
+(defattrs refresh-button-attrs []
+  {:display 'inline}
+  [:i.material-icons {:font-size "16pt"
+                      :vertical-align 'middle}]
+  [:.invisible {:visibility 'hidden}])
+
 (defn- data-source [selected-source-ids {:keys [id] :as s}]
   (let [sheet-id (<sub [:active-sheet-id])
         selected? (contains? @selected-source-ids id)]
     [:div
-     [:div.refresh-button
+     [:div (refresh-button-attrs)
       (if selected?
         [link>evt [:reload-sheet-source! sheet-id id]
          (icon :refresh)]

--- a/src/cljs/wish/views/sheet_builder_util.cljs
+++ b/src/cljs/wish/views/sheet_builder_util.cljs
@@ -76,8 +76,21 @@
 
    :position (when sticky?
                'sticky)
-   :top 0
-   })
+   :top 0}
+
+  [:.section-link
+   [:&.selected [:a {:color [["#000" :!important]]}
+                 (at-media media/dark-scheme
+                   {:color [["#fff" :!important]]})]]
+
+   [:.nav-link {:display 'flex
+                :align-items 'center}]
+
+   #_[:.icon {:display 'none}]
+   (at-media media/smartphones
+     [:.icon {:display 'block}]
+     [:.label {:display 'none}])
+   ])
 
 (defn- find-section
   [candidates target-id]
@@ -110,7 +123,8 @@
           {:class (when (= id current-section)
                     "selected")}
           [link {:href (sheet-url sheet-id :builder id)}
-           (:name info)]])]]
+           [:span.icon (:icon info)]
+           [:span.label (:name info)]]])]]
 
      [:div.sticky.header
       [:div (header-row)

--- a/src/cljs/wish/views/sheet_builder_util.cljs
+++ b/src/cljs/wish/views/sheet_builder_util.cljs
@@ -86,9 +86,7 @@
    [:.nav-link {:display 'flex
                 :align-items 'center}]
 
-   #_[:.icon {:display 'none}]
    (at-media media/smartphones
-     [:.icon {:display 'block}]
      [:.label {:display 'none}])
    ])
 

--- a/src/cljs/wish/views/sheet_builder_util.cljs
+++ b/src/cljs/wish/views/sheet_builder_util.cljs
@@ -9,7 +9,8 @@
             [wish.providers :as providers]
             [wish.style.media :as media]
             [wish.style.util :refer [linear-gradient]]
-            [wish.views.widgets :refer [link link>evt save-state] :refer-macros [icon]]))
+            [wish.views.widgets :refer [link link>evt save-state] :refer-macros [icon]]
+            [wish.views.widgets.circular-progress :refer [circular-progress]]))
 
 (defclass sections-class []
   {:display 'flex
@@ -25,25 +26,40 @@
 
 (defn count-max-options
   ([feature] (count-max-options feature nil))
-  ([{values :values
-     accepted? :max-options}
-    extra-info]
+  ([{:keys [max-options values]} extra-info]
    ; if it's a const number, we can skip some steps
-   (or (when (number? accepted?)
-         accepted?)
+   (or (when (number? max-options)
+         max-options)
 
-       (first
-         (keep
-           (fn [to-take]
-             (when-not (accepted? (merge
-                                    extra-info
-                                    {:features
-                                     (take to-take values)}))
-               (dec to-take)))
-           (range 1 (inc (count values)))))
+       (when-let [n (max-options extra-info)]
+         (when (number? n)
+           n))
 
        ;; fallback, I guess?
        (count values))))
+
+
+; ======= selected option count indicator =================
+
+(defattrs selected-option-counter-attrs []
+  {:display 'inline-flex
+   :vertical-align 'middle
+   :text-align 'center
+   :justify-content 'center
+   :align-items 'center
+   :width "40px"
+   :height "40px"
+   :font-size "14px"})
+
+(defn selected-option-counter [selected limit]
+  [:div (selected-option-counter-attrs)
+   (cond
+     (= selected limit) (icon :check-circle-outline)
+     (= 0 selected) [circular-progress 0 limit
+                     :stroke-width 4]
+
+     :else [circular-progress selected limit
+            :stroke-width 4])])
 
 
 ; ======= builder section routing =========================

--- a/src/cljs/wish/views/widgets/circular_progress.cljs
+++ b/src/cljs/wish/views/widgets/circular_progress.cljs
@@ -1,0 +1,46 @@
+(ns wish.views.widgets.circular-progress
+  (:require [garden.color :as color]
+            [garden.units :refer [px]]
+            [spade.core :refer [defattrs]]
+            [wish.style :as theme]
+            [wish.style.media :as media]))
+
+(defattrs circular-progress-attrs [width circumference stroke-width]
+  {:height (px width)
+   :width (px width)}
+
+  [:.slot {:stroke-width stroke-width
+           :stroke (color/transparentize theme/text-primary-on-light 0.75)}
+   (at-media media/dark-scheme
+     {:stroke (color/transparentize theme/text-primary-on-dark 0.75)})]
+
+  [:.circle {:stroke-dasharray [[circumference circumference]]
+             :stroke-width stroke-width
+             :stroke theme/text-primary-on-light
+
+             :transition [[:stroke-dashoffset "0.35s"]]
+             :transform "rotate(-90deg)"
+             :transform-origin [[:50% :50%]]}
+   (at-media media/dark-scheme
+     {:stroke theme/text-primary-on-dark})])
+
+(defn circular-progress
+  [current max & {:keys [stroke-width width]
+                  :or {stroke-width 4
+                       width 32}}]
+  (let [radius (* 0.5 width)
+        inner-radius (- (/ width 2) (* 2 stroke-width))
+        circumference (* 2 inner-radius js/Math.PI)
+        perc (/ current max)]
+    [:svg (circular-progress-attrs width circumference stroke-width)
+     [:circle.slot {:fill 'transparent
+                    :cx radius
+                    :cy radius
+                    :r inner-radius}]
+     [:circle.circle {:fill 'transparent
+                      :cx radius
+                      :cy radius
+                      :r inner-radius
+
+                      :stroke-dashoffset (* circumference (- 1.0 perc))}]]))
+

--- a/test/cljs/wish/views/sheet_builder_util_test.cljs
+++ b/test/cljs/wish/views/sheet_builder_util_test.cljs
@@ -9,6 +9,13 @@
              {:values [:a :b :c]
               :max-options 2}))))
 
+  (testing "simple fn-based :max-options"
+    (let [compiled (constantly 42)]
+      (is (= 42
+             (count-max-options
+               {:values [:a :b :c :d]
+                :max-options compiled})))))
+
   (testing "fn-based :max-options"
     (let [compiled (fn [{:keys [features]}]
                      (<= (count features) 3))]


### PR DESCRIPTION
This PR significantly improves the Builder UI (at last). There's still plenty more things we could try, but these changes are sufficient for one PR:

- Simplify builder navigation UX
- Collapse ability labels in builder on smaller devices
- Add icons to builder sections; hide the labels on smartphones
- Nicely indicate option selection limits more consistently
- Don't show selectable count for "Extra Feats"

See #138 for other improvements we'd like to explore.
