### PR TITLE
Add initial "availability group" concept; show "other" items in group

### DIFF
--- a/resources/sources/dnd5e/0-common/languages.edn
+++ b/resources/sources/dnd5e/0-common/languages.edn
@@ -28,5 +28,5 @@
       {:id kw
        :name label
        :desc (str "You can speak, read, and write " label ".")
-       :availability-attr kw})))
+       :availability-attr [:languages kw]})))
 

--- a/resources/sources/dnd5e/0-common/proficiencies.edn
+++ b/resources/sources/dnd5e/0-common/proficiencies.edn
@@ -35,7 +35,7 @@
         {:id kw
          :name label
          :implicit? true
-         :availability-attr kw})))
+         :availability-attr [:skill-proficiencies kw]})))
 
   (declare-list
 
@@ -49,7 +49,7 @@
         {:id expertise-kw
          :name label
          :implicit? true
-         :availability-attr expertise-kw
+         :availability-attr [:expertise expertise-kw]
          :available? (fn [#{attrs}]
                        (kw attrs))}))))
 
@@ -102,7 +102,7 @@
       {:id kw
        :name label
        :implicit? true
-       :availability-attr kw})))
+       :availability-attr [:proficiency kw]})))
 
 ; ======= Weapon proficiencies ============================
 
@@ -135,7 +135,7 @@
        :implicit? true
        :! (on-state
             (provide-attr [:weapon-kinds kind-kw] true)
-            (provide-attr kw true))})))
+            (provide-attr [:proficiency kw] true))})))
 
 (declare-list
  {:id :weapon-category-proficiencies
@@ -146,13 +146,13 @@
   :implicit? true
   :! (on-state
        (provide-attr [:weapon-categories :martial] true)
-       (provide-attr :proficiency/martial-weapons true))}
+       (provide-attr [:proficiency :proficiency/martial-weapons] true))}
  {:id :proficiency/simple-weapons
   :name "Simple Weapons"
   :implicit? true
   :! (on-state
        (provide-attr [:weapon-categories :simple] true)
-       (provide-attr :proficiency/simple-weapons true))})
+       (provide-attr [:proficiency :proficiency/simple-weapons] true))})
 
 
 ; ======= Armor proficiencies =============================
@@ -172,4 +172,4 @@
        :name label
        :implicit? true
        :! (on-state
-            (provide-attr kw true))})))
+            (provide-attr [:proficiency kw] true))})))

--- a/resources/sources/dnd5e/backgrounds/0-base.edn
+++ b/resources/sources/dnd5e/backgrounds/0-base.edn
@@ -49,6 +49,7 @@
           {:id :custom-bg/tools-or-languages
            :name "Proficiencies (Choose either 2 tools, 2 languages, or one of each.)"
            :implicit? true
+           :availability-groups [:languages :proficiency]
            :max-options 2
            :values [(items-from-list :all-languages)
                     (items-from-list :all-tool-proficiencies)]}))})

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -18,7 +18,8 @@
             [wish.util :refer [<sub >evt click>reset! click>swap!]]
             [wish.style.flex :as flex :refer [flex]]
             [wish.style.shared :as style]
-            [wish.views.sheet-builder-util :refer [campaign-manager
+            [wish.views.sheet-builder-util :refer [availability-group
+                                                   campaign-manager
                                                    data-source-manager
                                                    router
                                                    count-max-options
@@ -266,7 +267,8 @@
                   :doc #(<sub [:meta/options])}
 
              max-options (count-max-options f extra-info)
-             selected-count (count (get-option [instance-id]))
+             selected (get-option [instance-id])
+             selected-count (count selected)
 
              ; special cases: (should we have a flag on the feature?)
              count-options (not= :feats feature-id)]
@@ -289,6 +291,10 @@
                      (< selected-count max-options))
             [:div.content>div.selected-count
              "Selected " selected-count " / " max-options])
+
+          (when-let [group-ids (:availability-groups f)]
+            [:div.content
+             [availability-group instance-id group-ids]])
 
           [:div.content
            (when-let [desc (:desc f)]

--- a/src/cljs/wish/sheets/dnd5e/subs/proficiency.cljs
+++ b/src/cljs/wish/sheets/dnd5e/subs/proficiency.cljs
@@ -53,11 +53,12 @@
   (fn [entity-lists _]
     (->> entity-lists
          flatten
-         (mapcat :attrs)
+         (mapcat (fn [{:keys [attrs]}]
+                   (concat (:skill-proficiencies attrs)
+                           (:proficiency attrs))))
+         ; we now have a seq of proficiency -> true/false: clean up
          (keep (fn [[k v]]
-                 (when (and v
-                            (= "proficiency" (namespace k)))
-                   k)))
+                 (when v k)))
          (into #{}))))
 
 (reg-sub
@@ -129,17 +130,11 @@
 (reg-sub
   ::languages
   :<- [:sheet-engine-state]
-  :<- [:races]
-  :<- [:classes]
-  :<- [:effects]
-  (fn [[data-source & entity-lists] _]
-    (->> entity-lists
-         flatten
-         (mapcat :attrs)
-         (keep (fn [[k v]]
-                 (when (and v
-                            (= "lang" (namespace k)))
-                   k)))
+  :<- [:all-attrs]
+  (fn [[data-source all-attrs] _]
+    (->> all-attrs
+         :languages
+         keys
          (keep (partial feature-by-id data-source))
          (sort-by :name))))
 

--- a/src/cljs/wish/sheets/dnd5e/subs/util.cljs
+++ b/src/cljs/wish/sheets/dnd5e/subs/util.cljs
@@ -1,7 +1,7 @@
 (ns wish.sheets.dnd5e.subs.util
   (:require [clojure.string :as str]
             [wish-engine.core :as engine]
-            [wish.sources.util :as src-util]
+            [wish.sheets.util :as sheet-util]
             [wish.subs-util :refer [reg-id-sub]]
             [wish.util.string :as wstr]
             [wish.util :refer [->set]]))
@@ -25,20 +25,8 @@
                    (wstr/includes-any-case? n filter-str))))
     coll))
 
-(defn feature-by-id
-  ([container feature-id]
-   (cond
-     (keyword? feature-id)
-     (or (get-in container [:features feature-id])
-         (get-in container [:list-entities feature-id]))
-
-     ; actually, an option value:
-     (vector? feature-id)
-     (get-in container (into [:options] feature-id))))
-  ([data-source container feature-id]
-   (or (feature-by-id container feature-id)
-       (feature-by-id data-source feature-id)
-       (src-util/inflate-feature data-source container feature-id))))
+; TODO migrate instead of aliasing, probably
+(def feature-by-id sheet-util/feature-by-id)
 
 (defn feature-in-lists [engine-state entity-lists id]
   (or (feature-by-id engine-state id)

--- a/src/cljs/wish/sheets/util.cljs
+++ b/src/cljs/wish/sheets/util.cljs
@@ -1,7 +1,8 @@
 (ns ^{:author "Daniel Leong"
       :doc "Sheet-related utils"}
   wish.sheets.util
-  (:require [wish.subs-util :refer [active-sheet-id]]))
+  (:require [wish.sources.util :as src-util]
+            [wish.subs-util :refer [active-sheet-id]]))
 
 (defn unpack-id
   "Unpack a sheet id into its provider and
@@ -77,3 +78,21 @@
   [{:keys [db]} use-id]
   (when-let [sheet-id (active-sheet-id db)]
     (get-in db [:sheets sheet-id :limited-uses use-id])))
+
+
+; ======= wish-engine conveniences ========================
+
+(defn feature-by-id
+  ([container feature-id]
+   (cond
+     (keyword? feature-id)
+     (or (get-in container [:features feature-id])
+         (get-in container [:list-entities feature-id]))
+
+     ; actually, an option value:
+     (vector? feature-id)
+     (get-in container (into [:options] feature-id))))
+  ([data-source container feature-id]
+   (or (feature-by-id container feature-id)
+       (feature-by-id data-source feature-id)
+       (src-util/inflate-feature data-source container feature-id))))

--- a/src/cljs/wish/views/sheet_builder_util.cljs
+++ b/src/cljs/wish/views/sheet_builder_util.cljs
@@ -76,6 +76,27 @@
             :stroke-width 4])])
 
 
+; ======= availability group info =========================
+
+(defattrs availability-group-attrs []
+  {:padding-bottom "12px"}
+  [:.item {:display 'inline-block
+           :font-size "10pt"}
+   ["&:not(:last-child)" {:padding-right "0.5em"}
+    [:&:after {:content "','"}]]])
+
+(defn availability-group [instance-id group-ids]
+  (when-let [selected-other (seq (<sub [:options-selected-in-other-groups
+                                        instance-id
+                                        group-ids]))]
+    [:div (availability-group-attrs)
+     [:div.label "Acquired elsewhere:"]
+     [:div.items
+      (for [f selected-other]
+        ^{:key (:id f)}
+        [:div.item (:name f)])]]))
+
+
 ; ======= builder section routing =========================
 
 (defattrs builder-attrs []


### PR DESCRIPTION
See #138

The upshot of this PR is that for things like 5e skill proficiencies, which can be acquired in many places (ex: race, background, AND class) you can now see which other ones you've already acquired at any given source. This should obviate the need for flipping back and forth between different pages.

If a feature has an `:availability-attr` that is a vector, the first
keyword in that vector becomes its "availability group."

A feature implicitly "has" an availability group if its first two
options are part of the same availability group. Alternately, a feature
could manually specify which availability groups it contributes to
by specifying the `:availability-groups` key. This is useful for things
like the "pick any 2" for a custom background, which allows both tool
proficiencies and languages.
