### PR TITLE
Provide new feature infos on level up

### DIFF
--- a/resources/sources/dnd5e/classes/bard.edn
+++ b/resources/sources/dnd5e/classes/bard.edn
@@ -148,9 +148,9 @@ Your Bardic Inspiration die changes when you reach certain levels in this class.
                        {:id :bard/magic-secrets
                         :name "Magical Secrets"
                         :desc "You have plundered magical knowledge from a wide spectrum of disciplines. Choose two spells from any class, including this one. A spell you choose must be of a level you can cast, as shown on the Bard table, or a cantrip.
-                               The chosen spells count as bard spells for you and are included in the number in the Spells Known column of the Bard table.
-                               You learn two additional spells from any class at 14th level and again at 18th level."
-                        :max-options (fn [#{level}]
+The chosen spells count as bard spells for you and are included in the number in the Spells Known column of the Bard table.
+You learn two additional spells from any class at 14th level and again at 18th level."
+                        :max-options (let [level (:level state)]
                                        (cond
                                          (< level 14) 2
                                          (< level 18) 4

--- a/resources/sources/dnd5e/classes/ranger.edn
+++ b/resources/sources/dnd5e/classes/ranger.edn
@@ -55,7 +55,7 @@ Choose a type of favored enemy: aberrations, beasts, celestials, constructs, dra
 You have advantage on Wisdom (Survival) checks to track your favored enemies, as well as on Intelligence checks to recall information about them.
 When you gain this feature, you also learn one language of your choice that is spoken by your favored enemies, if they speak one at all.
 You choose one additional favored enemy, as well as an associated language, at 6th and 14th level. As you gain levels, your choices should reflect the types of monsters you have encountered on your adventures.",
-        :max-options (fn [#{level}] (cond (< level 6) 1 (< level 14) 2 :else 3)),
+        :max-options (let [level (:level state)] (cond (< level 6) 1 (< level 14) 2 :else 3)),
         :values
         [{:id :ranger/enemy-aberrations,
           :name "Favored Enemy: Aberrations",
@@ -119,7 +119,7 @@ While traveling for an hour or more in your favored terrain, you gain the follow
 • When you forage, you find twice as much food as you normally would.
 • While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.
 You choose additional favored terrain types at 6th and 10th level.",
-        :max-options (fn [#{level}] (cond (< level 6) 1 (< level 14) 2 :else 3)),
+        :max-options (let [level (:level state)] (cond (< level 6) 1 (< level 14) 2 :else 3)),
         :values
         [{:id :ranger/terrain-arctic, :name "Favored Terrain: Arctic"}
          {:id :ranger/terrain-coast, :name "Favored Terrain: Coast"}

--- a/resources/sources/dnd5e/classes/sorcerer.edn
+++ b/resources/sources/dnd5e/classes/sorcerer.edn
@@ -108,7 +108,8 @@ Any spell slot you create with this feature vanishes when you finish a long rest
           :desc
           "At 3rd level, you gain the ability to twist your spells to suit your needs. You gain two of the following Metamagic options of your choice. You gain another one at 10th and 17th level.
 You can use only one Metamagic option on a spell when you cast it, unless otherwise noted.",
-          :max-options (fn [#{level}] (cond (< level 10) 2 (< level 17) 3 :else 4))}))},
+          :max-options (let [level (:level state)]
+                         (cond (< level 10) 2 (< level 17) 3 :else 4))}))},
     4 {:! (on-state (provide-features :abi-or-feat))},
     8 {:! (on-state (provide-features :abi-or-feat))},
     12 {:! (on-state (provide-features :abi-or-feat))},

--- a/src/cljs/wish/events.cljs
+++ b/src/cljs/wish/events.cljs
@@ -359,15 +359,18 @@
               diff (set/difference (into #{} (keys new-features))
                                    (into #{} (keys old-features)))
 
-              ; TODO increase in available options for old features?
+              ; increase in available options for old features
               increased-options (->> old-features
                                      vals
-                                     (distinct-by :wish/instance-id)
+                                     (distinct-by (fn [f]
+                                                    (or (:wish/instance-id f)
+                                                        (:id f))))
                                      (filter :max-options)
                                      (map (juxt :max-options
                                                 (comp new-features :id)))
                                      (filter (fn [[old-max new-feature]]
-                                               (not= old-max (:max-options new-feature)))))
+                                               (not= old-max
+                                                     (:max-options new-feature)))))
 
               content [level-up-notification opts
                        :new-level new-level

--- a/src/cljs/wish/events.cljs
+++ b/src/cljs/wish/events.cljs
@@ -12,7 +12,7 @@
             [wish.inventory :as inv]
             [wish.push :as push]
             [wish.sheets.util :refer [update-uses update-sheet-path unpack-id]]
-            [wish.util :refer [invoke-callable update-dissoc]]))
+            [wish.util :refer [distinct-by invoke-callable update-dissoc]]))
 
 (reg-event-fx
   ::initialize-db
@@ -320,11 +320,10 @@
              (when (and (number? old-max)
                         (number? new-max)
                         (> new-max old-max))
-               (println (:name f) old-max " -> " new-max)
                ^{:key (:id f)}
                [:div.item
                 (- new-max old-max)
-                " new options for "
+                " additional options for "
                 (format-link f)])))]])]))
 
 (reg-event-fx
@@ -363,12 +362,12 @@
               ; TODO increase in available options for old features?
               increased-options (->> old-features
                                      vals
+                                     (distinct-by :wish/instance-id)
                                      (filter :max-options)
                                      (map (juxt :max-options
                                                 (comp new-features :id)))
                                      (filter (fn [[old-max new-feature]]
-                                               (not= old-max (:max-options new-feature))))
-                                     )
+                                               (not= old-max (:max-options new-feature)))))
 
               content [level-up-notification opts
                        :new-level new-level

--- a/src/cljs/wish/events.cljs
+++ b/src/cljs/wish/events.cljs
@@ -10,6 +10,7 @@
             [wish.inventory :as inv]
             [wish.push :as push]
             [wish.sheets.util :refer [update-uses update-sheet-path unpack-id]]
+            [wish.subs-util :as util]
             [wish.util :refer [invoke-callable update-dissoc]]))
 
 (reg-event-fx
@@ -291,6 +292,20 @@
 
       ; delete the sheet source to trigger a reload
       [:db :sheet-sources sheet-id] nil)))
+
+(reg-event-fx
+  :update-class-level
+  [trim-v]
+  (fn-traced [{:keys [db] :as cofx} [class-id new-level]]
+    (let [path [class-id :level]
+          sheet-id (util/active-sheet-id db)
+          sheet-level-path (concat [:sheets sheet-id :classes] path)
+          old (get-in db sheet-level-path)
+          updated (update-sheet-path cofx [:classes] assoc-in path new-level)]
+      (when (> new-level old)
+        (println "level up " old " -> " new-level))
+      updated
+      )))
 
 
 ; ======= sheet-related ====================================

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -30,6 +30,13 @@
             [wish.views.widgets.limited-select :refer [limited-select]]
             [wish.views.widgets.multi-limited-select]))
 
+(defn- feature-element-id [f]
+  (let [id (:id f)
+        space (namespace id)
+        n (name id)]
+    (str "feat-" space "-" n)))
+
+
 ; ======= CSS ==============================================
 
 (defattrs abilities-style []
@@ -258,7 +265,8 @@
         selected-count (count selected)
         count-options? (not (:unrestricted-options? f))]
     [:div.feature {:class (when (> (count (:wish/sort f)) 2)
-                           "provided")}
+                           "provided")
+                   :id (feature-element-id f)}
     [:h3.title
      (when count-options?
        [selected-option-counter
@@ -332,12 +340,29 @@
 
 ; ======= class management/level-up ========================
 
+(defattrs level-up-feature-link-attrs []
+  {:display 'inline-flex
+   :align-items 'center
+   :min-height "2em"}
+  [:.jump {:padding "0 8px"}])
+
 (defn- level-up-feature-link [f]
-  ; TODO can we provide links to specific feature instances?
-  [:a {:href "#"
-       :on-click (click>evt [:toggle-overlay
-                             [#'overlays/info f]])}
-   (:name f)])
+  [:div (level-up-feature-link-attrs)
+   [:a {:href "#"
+        :on-click (click>evt [:toggle-overlay
+                              [#'overlays/info f]])}
+    (:name f)]
+
+   (when (:max-options f)
+     [:a.jump {:href "#"
+               :on-click (fn-click
+                           (some-> (js/document.getElementById
+                                     (feature-element-id f))
+                                   (.scrollIntoView
+                                     #js {:behavior "smooth"
+                                          :block "center"
+                                          :inline "center"})))}
+      (icon :get-app)])])
 
 (def ^:private level-up-config
   {:format-link #'level-up-feature-link})

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -350,7 +350,8 @@
                 ; NOTE this seems to get triggered whenever this section is
                 ; rendered for some reason...
                 (when-not (= v (<sub [::subs/class-level (first path)]))
-                  (>evt [:update-meta [:classes] assoc-in path v])))}]
+                  (>evt [:update-class-level (first path) v])
+                  #_(>evt [:update-meta [:classes] assoc-in path v])))}]
 
      [:div.remove.clickable
       {:title (str "Remove " (:name class-info) " Class")

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -31,7 +31,8 @@
             [wish.views.widgets.multi-limited-select]))
 
 (defn- feature-element-id [f]
-  (let [id (:id f)
+  (let [id (or (:wish/instance-id f)
+               (:id f))
         space (namespace id)
         n (name id)]
     (str "feat-" space "-" n)))

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -388,8 +388,7 @@
                 ; rendered for some reason...
                 (when-not (= v (<sub [::subs/class-level (first path)]))
                   (>evt [:update-class-level (first path) v
-                         level-up-config])
-                  #_(>evt [:update-meta [:classes] assoc-in path v])))}]
+                         level-up-config])))}]
 
      [:div.remove.clickable
       {:title (str "Remove " (:name class-info) " Class")

--- a/src/cljs/wish/sheets/dnd5e/builder.cljs
+++ b/src/cljs/wish/sheets/dnd5e/builder.cljs
@@ -8,6 +8,7 @@
             [reagent-forms.core :refer [bind-fields]]
             [spade.core :refer [defattrs]]
             [wish.sheets.dnd5e.builder.data :as data]
+            [wish.sheets.dnd5e.overlays :as overlays]
             [wish.sheets.dnd5e.subs :as subs]
             [wish.sheets.dnd5e.subs.abilities :as abilities]
             [wish.sheets.dnd5e.subs.builder :as builder]
@@ -15,7 +16,7 @@
             [wish.sheets.dnd5e.events :as events]
             [wish.sheets.dnd5e.util :refer [mod->str]]
             [wish.style.media :as media]
-            [wish.util :refer [<sub >evt click>reset! click>swap!]]
+            [wish.util :refer [<sub >evt click>reset! click>evt click>swap!]]
             [wish.style.flex :as flex :refer [flex]]
             [wish.style.shared :as style]
             [wish.views.sheet-builder-util :refer [availability-group
@@ -331,6 +332,16 @@
 
 ; ======= class management/level-up ========================
 
+(defn- level-up-feature-link [f]
+  ; TODO can we provide links to specific feature instances?
+  [:a {:href "#"
+       :on-click (click>evt [:toggle-overlay
+                             [#'overlays/info f]])}
+   (:name f)])
+
+(def ^:private level-up-config
+  {:format-link #'level-up-feature-link})
+
 (defn class-section [class-info]
   [:div.class-section
    [:div.class-header
@@ -350,7 +361,8 @@
                 ; NOTE this seems to get triggered whenever this section is
                 ; rendered for some reason...
                 (when-not (= v (<sub [::subs/class-level (first path)]))
-                  (>evt [:update-class-level (first path) v])
+                  (>evt [:update-class-level (first path) v
+                         level-up-config])
                   #_(>evt [:update-meta [:classes] assoc-in path v])))}]
 
      [:div.remove.clickable

--- a/src/cljs/wish/views/notifiers.cljs
+++ b/src/cljs/wish/views/notifiers.cljs
@@ -3,6 +3,7 @@
             [wish.style.media :as media]
             [wish.util :refer [<sub click>evts]]
             [wish.events :as events]
+            [wish.views.error-boundary :refer [error-boundary]]
             [wish.views.widgets :refer [icon link>evt]]))
 
 (defattrs notifiers-attrs []
@@ -62,7 +63,9 @@
                  :> dismiss-event}
        (icon :close)]])
 
-   [:div.content content]
+   [:div.content
+    [error-boundary
+     content]]
 
    (when action-event
      [:div.action


### PR DESCRIPTION
Shows each new feature + when the number of `:max-options` for a feature
increased.

See #138 