### PR TITLE
Implement provide-able "ally categories"

### DIFF
--- a/resources/sources/dnd5e/classes/druid.edn
+++ b/resources/sources/dnd5e/classes/druid.edn
@@ -110,15 +110,18 @@ While you are transformed, the following rules apply:
                                             (< (:level state) 8) "1/2 or lower that doesn't have a flying speed, like a Crocadile."
                                             :else "1 or lower, like a Giant Eagle."))
                                :filter (cond
-                                        (< (:level state) 4) (fn [#{challenge speed}]
-                                                               (and (<= challenge 0.25)
+                                        (< (:level state) 4) (fn [#{challenge speed type}]
+                                                               (and (= :beast type)
+                                                                    (<= challenge 0.25)
                                                                     (not (.includes speed "fly"))
                                                                     (not (.includes speed "swim"))))
-                                        (< (:level state) 8) (fn [#{challenge speed}]
-                                                               (and (<= challenge 0.5)
+                                        (< (:level state) 8) (fn [#{challenge speed type}]
+                                                               (and (= :beast type)
+                                                                    (<= challenge 0.5)
                                                                     (not (.includes speed "fly"))))
-                                        :else (fn [#{challenge}]
-                                                (<= challenge 1)))}
+                                        :else (fn [#{challenge type}]
+                                                (and (= :beast type)
+                                                     (<= challenge 1))))}
                               )
                             )}
 

--- a/resources/sources/dnd5e/classes/druid.edn
+++ b/resources/sources/dnd5e/classes/druid.edn
@@ -98,7 +98,29 @@ While you are transformed, the following rules apply:
                                :restore-trigger :short-rest})
                             (provide-attr
                               [:action :druid/wild-shape]
-                              true))}
+                              true)
+
+                            (provide-to-list
+                              :wish/ally-categories
+                              {:id :druid/wild-shape-allies
+                               :name "Wild Shape"
+                               :desc (str "You can use your action to magically assume the shape of a beast that you have seen before with a challenge rating of "
+                                          (cond
+                                            (< (:level state) 4) "1/4 or lower that doesn't have a flying or swimming speed, like a Wolf."
+                                            (< (:level state) 8) "1/2 or lower that doesn't have a flying speed, like a Crocadile."
+                                            :else "1 or lower, like a Giant Eagle."))
+                               :filter (cond
+                                        (< (:level state) 4) (fn [#{challenge speed}]
+                                                               (and (<= challenge 0.25)
+                                                                    (not (.includes speed "fly"))
+                                                                    (not (.includes speed "swim"))))
+                                        (< (:level state) 8) (fn [#{challenge speed}]
+                                                               (and (<= challenge 0.5)
+                                                                    (not (.includes speed "fly"))))
+                                        :else (fn [#{challenge}]
+                                                (<= challenge 1)))}
+                              )
+                            )}
 
                       {:id :druid/circle
                        :name "Druid Circle"

--- a/resources/sources/dnd5e/creatures/srd-creatures.edn
+++ b/resources/sources/dnd5e/creatures/srd-creatures.edn
@@ -1,0 +1,11368 @@
+;; Auto-generated using the Polymorph project
+
+(declare-list
+  {:id :all-creatures
+   :type :5e/creature}
+
+
+  {:id :creatures/aboleth
+   :name "Aboleth"
+   :ac 17
+   :challenge 10
+   :hit-points "18d10 + 36"
+   :abilities {:str 21 :dex 9 :con 15 :int 18 :wis 15 :cha 18}
+   :senses "darkvision 120 ft., passive Perception 20"
+   :size :large
+   :type :aberration
+   :speed "10 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-aboleth/amphibious
+           :name "Amphibious"
+           :desc "The aboleth can breathe air and water."})
+        (provide-feature
+          {:id :creatures-aboleth/mucous-cloud
+           :name "Mucous Cloud"
+           :desc "While underwater, the aboleth is surrounded by transformative mucus. A creature that touches the aboleth or that hits it with a melee attack while within 5 feet of it must make a DC 14 Constitution saving throw. On a failure, the creature is diseased for 1d4 hours. The diseased creature can breathe only underwater."})
+        (provide-feature
+          {:id :creatures-aboleth/probing-telepathy
+           :name "Probing Telepathy"
+           :desc "If a creature communicates telepathically with the aboleth, the aboleth learns the creature’s greatest desires if the aboleth can see the creature."})
+        (provide-attr
+          [:attacks :creatures-aboleth/multiattack]
+          {:id :creatures-aboleth/multiattack
+           :name "Multiattack"
+           :desc "The aboleth makes three tentacle attacks."})
+        (provide-attr
+          [:attacks :creatures-aboleth/tentacle]
+          {:id :creatures-aboleth/tentacle
+           :name "Tentacle"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 10 ft., one target. _Hit: _12 (2d6 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 14 Constitution saving throw or become diseased. The disease has no effect for 1 minute and can be removed by any magic that cures disease. After 1 minute, the diseased creature’s skin becomes translucent and slimy, the creature can’t regain hit points unless it is underwater, and the disease can be removed only by _heal _or another disease-curing spell of 6th level or higher. When the creature is outside a body of water, it takes 6 (1d12) acid damage every 10 minutes unless moisture is applied to the skin before 10 minutes have passed."
+           :damage :bludgeoning
+           :dice "2d6+5"
+           :to-hit 9})
+        (provide-attr
+          [:attacks :creatures-aboleth/tail]
+          {:id :creatures-aboleth/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 10 ft. one target. _Hit: _15 (3d6 + 5) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d6+5"
+           :to-hit 9})
+        (provide-feature
+          {:id :creatures-aboleth/enslave
+           :name "Enslave (3/Day)"
+           :desc "The aboleth targets one creature it can see within 30 feet of it. The target must succeed on a DC 14 Wisdom saving throw or be magically charmed by the aboleth until the aboleth dies or until it is on a different plane of existence from the target. The charmed target is under the aboleth’s control and can’t take reactions, and the aboleth and the target can communicate telepathically with each other over any distance."})
+        (provide-feature
+          {:id :creatures-aboleth/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-aboleth/detect
+           :name "Detect"
+           :desc "The aboleth makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-aboleth/tail-swipe
+           :name "Tail Swipe"
+           :desc "The aboleth makes one tail attack."})
+        (provide-feature
+          {:id :creatures-aboleth/psychic-drain
+           :name "Psychic Drain (Costs 2 Actions)"
+           :desc "One creature charmed by the aboleth takes 10 (3d6) psychic damage, and the aboleth regains hit points equal to the damage the creature takes."}))}
+  {:id :creatures/deva
+   :name "Deva"
+   :ac 17
+   :challenge 10
+   :hit-points "16d8 + 64"
+   :abilities {:str 18 :dex 18 :con 18 :int 17 :wis 20 :cha 20}
+   :senses "darkvision 120 ft., passive Perception 19"
+   :size :medium
+   :type :celestial
+   :speed "30 ft., fly 90 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-deva/angelic-weapons
+           :name "Angelic Weapons"
+           :desc "The deva’s weapon attacks are magical. When the deva hits with any weapon, the weapon deals an extra 4d8 radiant damage (included in the attack)."})
+        (provide-feature
+          {:id :creatures-deva/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The deva’s spellcasting ability is Charisma (spell save DC 17). The deva can innately cast the following spells, requiring only verbal components:"})
+        (provide-feature
+          {:id :creatures-deva/magic-resistance
+           :name "Magic Resistance"
+           :desc "The deva has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-deva/multiattack]
+          {:id :creatures-deva/multiattack
+           :name "Multiattack"
+           :desc "The deva makes two melee attacks."})
+        (provide-attr
+          [:attacks :creatures-deva/mace]
+          {:id :creatures-deva/mace
+           :name "Mace"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _7 (1d6 + 4) bludgeoning damage plus 18 (4d8) radiant damage."
+           :damage :bludgeoning
+           :dice "1d6+4"
+           :to-hit 8})
+        (provide-feature
+          {:id :creatures-deva/healing-touch
+           :name "Healing Touch (3/Day)"
+           :desc "The deva touches another creature. The target magically regains 20 (4d8 + 2) hit points and is freed from any curse, disease, poison, blindness, or deafness."})
+        (provide-feature
+          {:id :creatures-deva/change-shape
+           :name "Change Shape"
+           :desc "The deva magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the deva’s choice)."}))}
+  {:id :creatures/planetar
+   :name "Planetar"
+   :ac 19
+   :challenge 16
+   :hit-points "16d10 + 112"
+   :abilities {:str 24 :dex 20 :con 24 :int 19 :wis 22 :cha 25}
+   :senses "truesight 120 ft., passive Perception 21"
+   :size :large
+   :type :celestial
+   :speed "40 ft., fly 120 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-planetar/angelic-weapons
+           :name "Angelic Weapons"
+           :desc "The planetar’s weapon attacks are magical. When the planetar hits with any weapon, the weapon deals an extra 5d8 radiant damage (included in the attack)."})
+        (provide-feature
+          {:id :creatures-planetar/divine-awareness
+           :name "Divine Awareness"
+           :desc "The planetar knows if it hears a lie."})
+        (provide-feature
+          {:id :creatures-planetar/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The planetar’s spellcasting ability is Charisma (spell save DC 20). The planetar can innately cast the following spells, requiring no material components:"})
+        (provide-feature
+          {:id :creatures-planetar/magic-resistance
+           :name "Magic Resistance"
+           :desc "The planetar has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-planetar/multiattack]
+          {:id :creatures-planetar/multiattack
+           :name "Multiattack"
+           :desc "The planetar makes two melee attacks."})
+        (provide-attr
+          [:attacks :creatures-planetar/greatsword]
+          {:id :creatures-planetar/greatsword
+           :name "Greatsword"
+           :desc "_Melee Weapon Attack: _+12 to hit, reach 5 ft., one target. _Hit: _21 (4d6 + 7) slashing damage plus 22 (5d8) radiant damage."
+           :damage :slashing
+           :dice "4d6+7"
+           :to-hit 12})
+        (provide-feature
+          {:id :creatures-planetar/healing-touch
+           :name "Healing Touch (4/Day)"
+           :desc "The planetar touches another creature. The target magically regains 30 (6d8 + 3) hit points and is freed from any curse, disease, poison, blindness, or deafness."}))}
+  {:id :creatures/solar
+   :name "Solar"
+   :ac 21
+   :challenge 21
+   :hit-points "18d10 + 144"
+   :abilities {:str 26 :dex 22 :con 26 :int 25 :wis 25 :cha 30}
+   :senses "truesight 120 ft., passive Perception 24"
+   :size :large
+   :type :celestial
+   :speed "50 ft., fly 150 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-solar/angelic-weapons
+           :name "Angelic Weapons"
+           :desc "The solar’s weapon attacks are magical. When the solar hits with any weapon, the weapon deals an extra 6d8 radiant damage (included in the attack)."})
+        (provide-feature
+          {:id :creatures-solar/divine-awareness
+           :name "Divine Awareness"
+           :desc "The solar knows if it hears a lie."})
+        (provide-feature
+          {:id :creatures-solar/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The solar’s spellcasting ability is Charisma (spell save DC 25). It can innately cast the following spells, requiring no material components:"})
+        (provide-feature
+          {:id :creatures-solar/magic-resistance
+           :name "Magic Resistance"
+           :desc "The solar has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-solar/multiattack]
+          {:id :creatures-solar/multiattack
+           :name "Multiattack"
+           :desc "The solar makes two greatsword attacks."})
+        (provide-attr
+          [:attacks :creatures-solar/greatsword]
+          {:id :creatures-solar/greatsword
+           :name "Greatsword"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 5 ft., one target. _Hit: _22 (4d6 + 8) slashing damage plus 27 (6d8) radiant damage."
+           :damage :slashing
+           :dice "4d6+8"
+           :to-hit 15})
+        (provide-attr
+          [:attacks :creatures-solar/slaying-longbow]
+          {:id :creatures-solar/slaying-longbow
+           :name "Slaying Longbow"
+           :desc "_Ranged Weapon Attack: _+13 to hit, range 150/600 ft., one target. _Hit: _15 (2d8 + 6) piercing damage plus 27 (6d8) radiant damage. If the target is a creature that has 100 hit points or fewer, it must succeed on a DC 15 Constitution saving throw or die."
+           :damage :piercing
+           :dice "2d8+6"
+           :to-hit 13})
+        (provide-feature
+          {:id :creatures-solar/flying-sword
+           :name "Flying Sword"
+           :desc "The solar releases its greatsword to hover magically in an unoccupied space within 5 feet of it. If the solar can see the sword, the solar can mentally command it as a bonus action to fly up to 50 feet and either make one attack against a target or return to the solar’s hands. If the hovering sword is targeted by any effect, the solar is considered to be holding it. The hovering sword falls if the solar dies."})
+        (provide-feature
+          {:id :creatures-solar/healing-touch
+           :name "Healing Touch (4/Day)"
+           :desc "The solar touches another creature. The target magically regains 40 (8d8 + 4) hit points and is freed from any curse, disease, poison, blindness, or deafness."})
+        (provide-feature
+          {:id :creatures-solar/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-solar/teleport
+           :name "Teleport"
+           :desc "The solar magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."})
+        (provide-feature
+          {:id :creatures-solar/searing-burst
+           :name "Searing Burst (Costs 2 Actions)"
+           :desc "The solar emits magical, divine energy. Each creature of its choice in a 10-foot radius must make a DC 23 Dexterity saving throw, taking 14 (4d6) fire damage plus 14 (4d6) radiant damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-solar/blinding-gaze
+           :name "Blinding Gaze (Costs 3 Actions)"
+           :desc "The solar targets one creature it can see within 30 feet of it. If the target can see it, the target must succeed on a DC 15 Constitution saving throw or be blinded until magic such as the _lesser restoration _spell removes the blindness."}))}
+  {:id :creatures/animated-armor
+   :name "Animated Armor"
+   :ac 18
+   :challenge 1
+   :hit-points "6d8 + 6"
+   :abilities {:str 14 :dex 11 :con 13 :int 1 :wis 3 :cha 1}
+   :senses "blindsight 60 ft. (blind beyond this radius), passive Perception 6"
+   :size :medium
+   :type :construct
+   :speed "25 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-animated-armor/antimagic-susceptibility
+           :name "Antimagic Susceptibility"
+           :desc "The armor is incapacitated while in the area of an _antimagic field. _If targeted by _dispel magic,_ the armor must succeed on a Constitution saving throw against the caster’s spell save DC or fall unconscious for 1 minute."})
+        (provide-feature
+          {:id :creatures-animated-armor/false-appearance
+           :name "False Appearance"
+           :desc "While the armor remains motionless, it is indistinguishable from a normal suit of armor."})
+        (provide-attr
+          [:attacks :creatures-animated-armor/multiattack]
+          {:id :creatures-animated-armor/multiattack
+           :name "Multiattack"
+           :desc "The armor makes two melee attacks."})
+        (provide-attr
+          [:attacks :creatures-animated-armor/slam]
+          {:id :creatures-animated-armor/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/flying-sword
+   :name "Flying Sword"
+   :ac 17
+   :challenge 0.25
+   :hit-points "5d6"
+   :abilities {:str 12 :dex 15 :con 11 :int 1 :wis 5 :cha 1}
+   :senses "blindsight 60 ft. (blind beyond this radius), passive Perception 7"
+   :size :small
+   :type :construct
+   :speed "0 ft., fly 50 ft. (hover)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-flying-sword/antimagic-susceptibility
+           :name "Antimagic Susceptibility"
+           :desc "The sword is incapacitated while in the area of an _antimagic field. _If targeted by _dispel magic,_ the sword must succeed on a Constitution saving throw against the caster’s spell save DC or fall unconscious for 1 minute."})
+        (provide-feature
+          {:id :creatures-flying-sword/false-appearance
+           :name "False Appearance"
+           :desc "While the sword remains motionless and isn’t flying, it is indistinguishable from a normal sword."})
+        (provide-attr
+          [:attacks :creatures-flying-sword/longsword]
+          {:id :creatures-flying-sword/longsword
+           :name "Longsword"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _5 (1d8 + 1) slashing damage."
+           :damage :slashing
+           :dice "1d8+1"
+           :to-hit 3}))}
+  {:id :creatures/rug-of-smothering
+   :name "Rug of Smothering"
+   :ac 12
+   :challenge 2
+   :hit-points "6d10"
+   :abilities {:str 17 :dex 14 :con 10 :int 1 :wis 3 :cha 1}
+   :senses "blindsight 60 ft. (blind beyond this radius), passive Perception 6"
+   :size :large
+   :type :construct
+   :speed "10 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-rug-of-smothering/antimagic-susceptibility
+           :name "Antimagic Susceptibility"
+           :desc "The rug is incapacitated while in the area of an _antimagic field. _If targeted by _dispel magic,_ the rug must succeed on a Constitution saving throw against the caster’s spell save DC or fall unconscious for 1 minute."})
+        (provide-feature
+          {:id :creatures-rug-of-smothering/damage-transfer
+           :name "Damage Transfer"
+           :desc "While it is grappling a creature, the rug takes only half the damage dealt to it, and the creature grappled by the rug takes the other half."})
+        (provide-feature
+          {:id :creatures-rug-of-smothering/false-appearance
+           :name "False Appearance"
+           :desc "While the rug remains motionless, it is indistinguishable from a normal rug."})
+        (provide-attr
+          [:attacks :creatures-rug-of-smothering/smother]
+          {:id :creatures-rug-of-smothering/smother
+           :name "Smother"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one Medium or smaller creature. _Hit: _The creature is grappled (escape DC 13). Until this grapple ends, the target is restrained, blinded, and at risk of suffocating, and the rug can’t smother another target. In addition, at the start of each of the target’s turns, the target takes 10 (2d6 + 3) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/ankheg
+   :name "Ankheg"
+   :ac 14
+   :challenge 2
+   :hit-points "6d10 + 6"
+   :abilities {:str 17 :dex 11 :con 13 :int 1 :wis 13 :cha 6}
+   :senses "darkvision 60 ft., tremorsense 60 ft., passive Perception 11"
+   :size :large
+   :type :monstrosity
+   :speed "30 ft., burrow 10 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-ankheg/bite]
+          {:id :creatures-ankheg/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) slashing damage plus 3 (1d6) acid damage. If the target is a Large or smaller creature, it is grappled (escape DC 13). Until this grapple ends, the ankheg can bite only the grappled creature and has advantage on attack rolls to do so."
+           :damage :slashing
+           :dice "2d6+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-ankheg/acid-spray
+           :name "Acid Spray (Recharge 6)"
+           :desc "The ankheg spits acid in a line that is 30 feet long and 5 feet wide, provided that it has no creature grappled. Each creature in that line must make a DC 13 Dexterity saving throw, taking 10 (3d6) acid damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/azer
+   :name "Azer"
+   :ac 17
+   :challenge 2
+   :hit-points "6d8 + 12"
+   :abilities {:str 17 :dex 12 :con 15 :int 12 :wis 13 :cha 10}
+   :senses "passive Perception 11"
+   :size :medium
+   :type :elemental
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-azer/heated-body
+           :name "Heated Body"
+           :desc "A creature that touches the azer or hits it with a melee attack while within 5 feet of it takes 5 (1d10) fire damage."})
+        (provide-feature
+          {:id :creatures-azer/heated-weapons
+           :name "Heated Weapons"
+           :desc "When the azer hits with a metal melee weapon, it deals an extra 3 (1d6) fire damage (included in the attack)."})
+        (provide-feature
+          {:id :creatures-azer/illumination
+           :name "Illumination"
+           :desc "The azer sheds bright light in a 10-foot radius and dim light for an additional 10 feet."})
+        (provide-attr
+          [:attacks :creatures-azer/warhammer]
+          {:id :creatures-azer/warhammer
+           :name "Warhammer"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) bludgeoning damage, or 8 (1d10 + 3) bludgeoning damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage."
+           :damage :bludgeoning
+           :dice "1d8+3"
+           :to-hit 5}))}
+  {:id :creatures/basilisk
+   :name "Basilisk"
+   :ac 15
+   :challenge 3
+   :hit-points "8d8 + 16"
+   :abilities {:str 16 :dex 8 :con 15 :int 2 :wis 8 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 9"
+   :size :medium
+   :type :monstrosity
+   :speed "20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-basilisk/petrifying-gaze
+           :name "Petrifying Gaze"
+           :desc "If a creature starts its turn within 30 feet of the basilisk and the two of them can see each other, the basilisk can force the creature to make a DC 12 Constitution saving throw if the basilisk isn’t incapacitated. On a failed save, the creature magically begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified until freed by the _greater restoration _spell or other magic."})
+        (provide-attr
+          [:attacks :creatures-basilisk/bite]
+          {:id :creatures-basilisk/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. H_it: _10 (2d6 + 3) piercing damage plus 7 (2d6) poison damage."
+           :damage :piercing
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/bugbear
+   :name "Bugbear"
+   :ac 16
+   :challenge 1
+   :hit-points "5d8 + 5"
+   :abilities {:str 15 :dex 14 :con 13 :int 8 :wis 11 :cha 9}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-bugbear/brute-
+           :name "Brute."
+           :desc ""})
+        (provide-feature
+          {:id :creatures-bugbear/surprise-attack
+           :name "Surprise Attack"
+           :desc "If the bugbear surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 7 (2d6) damage from the attack."})
+        (provide-attr
+          [:attacks :creatures-bugbear/morningstar]
+          {:id :creatures-bugbear/morningstar
+           :name "Morningstar"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _11 (2d8 + 2) piercing damage."
+           :damage :piercing
+           :dice "2d8+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-bugbear/javelin]
+          {:id :creatures-bugbear/javelin
+           :name "Javelin"
+           :desc "_Melee or Ranged Weapon Attack: _+4 to hit, reach 5 ft. or range 30/120 ft., one target. _Hit: _9 (2d6 + 2) piercing damage in melee or 5 (1d6 + 2) piercing damage at range."
+           :damage :piercing
+           :dice "2d6+2"
+           :to-hit 4}))}
+  {:id :creatures/bulette
+   :name "Bulette"
+   :ac 17
+   :challenge 5
+   :hit-points "9d10 + 45"
+   :abilities {:str 19 :dex 11 :con 21 :int 2 :wis 10 :cha 5}
+   :senses "darkvision 60 ft., tremorsense 60 ft., passive Perception 16"
+   :size :large
+   :type :monstrosity
+   :speed "40 ft., burrow 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-bulette/standing-leap
+           :name "Standing Leap"
+           :desc "The bulette’s long jump is up to 30 feet and its high jump is up to 15 feet, with or without a running start."})
+        (provide-attr
+          [:attacks :creatures-bulette/bite]
+          {:id :creatures-bulette/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _30 (4d12 + 4) piercing damage."
+           :damage :piercing
+           :dice "4d12+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-bulette/deadly-leap
+           :name "Deadly Leap"
+           :desc "If the bulette jumps at least 15 feet as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must succeed on a DC 16 Strength or Dexterity saving throw (target’s choice) or be knocked prone and take 14 (3d6 + 4) bludgeoning damage plus 14 (3d6 + 4) slashing damage. On a successful save, the creature takes only half the damage, isn’t knocked prone, and is pushed 5 feet out of the bulette’s space into an unoccupied space of the creature’s choice. If no unoccupied space is within range, the creature instead falls prone in the bulette’s space."}))}
+  {:id :creatures/centaur
+   :name "Centaur"
+   :ac 12
+   :challenge 2
+   :hit-points "6d10 + 12"
+   :abilities {:str 18 :dex 14 :con 14 :int 9 :wis 13 :cha 11}
+   :senses "passive Perception 13"
+   :size :large
+   :type :monstrosity
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-centaur/charge
+           :name "Charge"
+           :desc "If the centaur moves at least 30 feet straight toward a target and then hits it with a pike attack on the same turn, the target takes an extra 10 (3d6) piercing damage."})
+        (provide-attr
+          [:attacks :creatures-centaur/multiattack]
+          {:id :creatures-centaur/multiattack
+           :name "Multiattack"
+           :desc "The centaur makes two attacks: one with its pike and one with its hooves or two with its longbow."})
+        (provide-attr
+          [:attacks :creatures-centaur/pike]
+          {:id :creatures-centaur/pike
+           :name "Pike"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one target. _Hit: _9 (1d10 + 4) piercing damage."
+           :damage :piercing
+           :dice "1d10+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-centaur/hooves]
+          {:id :creatures-centaur/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d6+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-centaur/longbow]
+          {:id :creatures-centaur/longbow
+           :name "Longbow"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 150/600 ft., one target. _Hit: _6 (1d8 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 4}))}
+  {:id :creatures/chimera
+   :name "Chimera"
+   :ac 14
+   :challenge 6
+   :hit-points "12d10 + 48"
+   :abilities {:str 19 :dex 11 :con 19 :int 3 :wis 14 :cha 10}
+   :senses "darkvision 60 ft., passive Perception 18"
+   :size :large
+   :type :monstrosity
+   :speed "30 ft., fly 60 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-chimera/multiattack]
+          {:id :creatures-chimera/multiattack
+           :name "Multiattack"
+           :desc "The chimera makes three attacks: one with its bite, one with its horns, and one with its claws. When its fire breath is available, it can use the breath in place of its bite or horns."})
+        (provide-attr
+          [:attacks :creatures-chimera/bite]
+          {:id :creatures-chimera/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-chimera/horns]
+          {:id :creatures-chimera/horns
+           :name "Horns"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _10 (1d12 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d12+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-chimera/claws]
+          {:id :creatures-chimera/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-chimera/fire-breath
+           :name "Fire Breath (Recharge 5–6)"
+           :desc "The dragon head exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 31 (7d8) fire damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/chuul
+   :name "Chuul"
+   :ac 16
+   :challenge 4
+   :hit-points "11d10 + 33"
+   :abilities {:str 19 :dex 10 :con 16 :int 5 :wis 11 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :large
+   :type :aberration
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-chuul/amphibious
+           :name "Amphibious"
+           :desc "The chuul can breathe air and water."})
+        (provide-feature
+          {:id :creatures-chuul/sense-magic
+           :name "Sense Magic"
+           :desc "The chuul senses magic within 120 feet of it at will. This trait otherwise works like the _detect magic _spell but isn’t itself magical."})
+        (provide-attr
+          [:attacks :creatures-chuul/multiattack]
+          {:id :creatures-chuul/multiattack
+           :name "Multiattack"
+           :desc "The chuul makes two pincer attacks. If the chuul is grappling a creature, the chuul can also use its tentacles once."})
+        (provide-attr
+          [:attacks :creatures-chuul/pincer]
+          {:id :creatures-chuul/pincer
+           :name "Pincer"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one target. _Hit: _11 (2d6 + 4) bludgeoning damage. The target is grappled (escape DC 14) if it is a Large or smaller creature and the chuul doesn’t have two other creatures grappled."
+           :damage :bludgeoning
+           :dice "2d6+4"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-chuul/tentacles
+           :name "Tentacles"
+           :desc "One creature grappled by the chuul must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. Until this poison ends, the target is paralyzed. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."}))}
+  {:id :creatures/cloaker
+   :name "Cloaker"
+   :ac 14
+   :challenge 8
+   :hit-points "12d10 + 12"
+   :abilities {:str 17 :dex 15 :con 12 :int 13 :wis 12 :cha 14}
+   :senses "darkvision 60 ft., passive Perception 11"
+   :size :large
+   :type :aberration
+   :speed "10 ft., fly 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-cloaker/damage-transfer
+           :name "Damage Transfer"
+           :desc "While attached to a creature, the cloaker takes only half the damage dealt to it (rounded down), and that creature takes the other half."})
+        (provide-feature
+          {:id :creatures-cloaker/false-appearance
+           :name "False Appearance"
+           :desc "While the cloaker remains motionless without its underside exposed, it is indistinguishable from a dark leather cloak."})
+        (provide-feature
+          {:id :creatures-cloaker/light-sensitivity
+           :name "Light Sensitivity"
+           :desc "While in bright light, the cloaker has disadvantage on attack rolls and Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-cloaker/multiattack]
+          {:id :creatures-cloaker/multiattack
+           :name "Multiattack"
+           :desc "The cloaker makes two attacks: one with its bite and one with its tail."})
+        (provide-attr
+          [:attacks :creatures-cloaker/bite]
+          {:id :creatures-cloaker/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one creature. _Hit: _10 (2d6 + 3) piercing damage, and if the target is Large or smaller, the cloaker attaches to it. If the cloaker has advantage against the target, the cloaker attaches to the target’s head, and the target is blinded and unable to breathe while the cloaker is attached. While attached, the cloaker can make this attack only against the target and has advantage on the attack roll. The cloaker can detach itself by spending 5 feet of its movement. A creature, including the target, can take its action to detach the cloaker by succeeding on a DC 16 Strength check."
+           :damage :piercing
+           :dice "2d6+3"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-cloaker/tail]
+          {:id :creatures-cloaker/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one creature. _Hit: _7 (1d8 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d8+3"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-cloaker/moan
+           :name "Moan"
+           :desc "Each creature within 60 feet of the cloaker that can hear its moan and that isn’t an aberration must succeed on a DC 13 Wisdom saving throw or become frightened until the end of the cloaker’s next turn. If a creature’s saving throw is successful, the creature is immune to the cloaker’s moan for the next 24 hours"})
+        (provide-feature
+          {:id :creatures-cloaker/phantasms
+           :name "Phantasms (Recharges after a Short or Long Rest)"
+           :desc "The cloaker magically creates three illusory duplicates of itself if it isn’t in bright light. The duplicates move with it and mimic its actions, shifting position so as to make it impossible to track which cloaker is the real one. If the cloaker is ever in an area of bright light, the duplicates disappear."}))}
+  {:id :creatures/cockatrice
+   :name "Cockatrice"
+   :ac 11
+   :challenge 0.5
+   :hit-points "6d6 + 6"
+   :abilities {:str 6 :dex 12 :con 12 :int 2 :wis 13 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 11"
+   :size :small
+   :type :monstrosity
+   :speed "20 ft., fly 40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-cockatrice/bite]
+          {:id :creatures-cockatrice/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one creature. _Hit: _3 (1d4 + 1) piercing damage, and the target must succeed on a DC 11 Constitution saving throw against being magically petrified. On a failed save, the creature begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified for 24 hours."
+           :damage :piercing
+           :dice "1d4+1"
+           :to-hit 3}))}
+  {:id :creatures/couatl
+   :name "Couatl"
+   :ac 19
+   :challenge 4
+   :hit-points "13d8 + 39"
+   :abilities {:str 16 :dex 20 :con 17 :int 18 :wis 20 :cha 18}
+   :senses "truesight 120 ft., passive Perception 15"
+   :size :medium
+   :type :celestial
+   :speed "30 ft., fly 90 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-couatl/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The couatl’s spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring only verbal components:"})
+        (provide-feature
+          {:id :creatures-couatl/magic-weapons
+           :name "Magic Weapons"
+           :desc "The couatl’s weapon attacks are magical."})
+        (provide-feature
+          {:id :creatures-couatl/shielded-mind
+           :name "Shielded Mind"
+           :desc "The couatl is immune to scrying and to any effect that would sense its emotions, read its thoughts, or detect its location."})
+        (provide-attr
+          [:attacks :creatures-couatl/bite]
+          {:id :creatures-couatl/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one creature. _Hit: _8 (1d6 + 5) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 24 hours. Until this poison ends, the target is unconscious. Another creature can use an action to shake the target awake."
+           :damage :piercing
+           :dice "1d6+5"
+           :to-hit 8})
+        (provide-attr
+          [:attacks :creatures-couatl/constrict]
+          {:id :creatures-couatl/constrict
+           :name "Constrict"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one Medium or smaller creature. _Hit: _10 (2d6 + 3) bludgeoning damage, and the target is grappled (escape DC 15). Until this grapple ends, the target is restrained, and the couatl can’t constrict another target."
+           :damage :bludgeoning
+           :dice "2d6+3"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-couatl/change-shape
+           :name "Change Shape"
+           :desc "The couatl magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the couatl’s choice)."}))}
+  {:id :creatures/darkmantle
+   :name "Darkmantle"
+   :ac 11
+   :challenge 0.5
+   :hit-points "5d6 + 5"
+   :abilities {:str 16 :dex 12 :con 13 :int 2 :wis 10 :cha 5}
+   :senses "blindsight 60 ft., passive Perception 10"
+   :size :small
+   :type :monstrosity
+   :speed "10 ft., fly 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-darkmantle/echolocation
+           :name "Echolocation"
+           :desc "The darkmantle can’t use its blindsight while deafened."})
+        (provide-feature
+          {:id :creatures-darkmantle/false-appearance
+           :name "False Appearance"
+           :desc "While the darkmantle remains motionless, it is indistinguishable from a cave formation such as a stalactite or stalagmite."})
+        (provide-attr
+          [:attacks :creatures-darkmantle/crush]
+          {:id :creatures-darkmantle/crush
+           :name "Crush"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one creature. _Hit: _6 (1d6 + 3) bludgeoning damage, and the darkmantle attaches to the target. If the target is Medium or smaller and the darkmantle has advantage on the attack roll, it attaches by engulfing the target’s head, and the target is also blinded and unable to breathe while the darkmantle is attached in this way."
+           :damage :bludgeoning
+           :dice "1d6+3"
+           :to-hit 5}))}
+  {:id :creatures/balor
+   :name "Balor"
+   :ac 19
+   :challenge 19
+   :hit-points "21d12 + 126"
+   :abilities {:str 26 :dex 15 :con 22 :int 20 :wis 16 :cha 22}
+   :senses "truesight 120 ft., passive Perception 13"
+   :size :huge
+   :type :fiend
+   :speed "40 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-balor/death-throes
+           :name "Death Throes"
+           :desc "When the balor dies, it explodes, and each creature within 30 feet of it must make a DC 20 Dexterity saving throw, taking 70 (20d6) fire damage on a failed save, or half as much damage on a successful one. The explosion ignites flammable objects in that area that aren’t being worn or carried, and it destroys the balor’s weapons."})
+        (provide-feature
+          {:id :creatures-balor/fire-aura
+           :name "Fire Aura"
+           :desc "At the start of each of the balor’s turns, each creature within 5 feet of it takes 10 (3d6) fire damage, and flammable objects in the aura that aren’t being worn or carried ignite. A creature that touches the balor or hits it with a melee attack while within 5 feet of it takes 10 (3d6) fire damage."})
+        (provide-feature
+          {:id :creatures-balor/magic-resistance
+           :name "Magic Resistance"
+           :desc "The balor has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-balor/magic-weapons
+           :name "Magic Weapons"
+           :desc "The balor’s weapon attacks are magical."})
+        (provide-attr
+          [:attacks :creatures-balor/multiattack]
+          {:id :creatures-balor/multiattack
+           :name "Multiattack"
+           :desc "The balor makes two attacks: one with its longsword and one with its whip."})
+        (provide-attr
+          [:attacks :creatures-balor/longsword]
+          {:id :creatures-balor/longsword
+           :name "Longsword"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 10 ft., one target. _Hit: _21 (3d8 + 8) slashing damage plus 13 (3d8) lightning damage. If the balor scores a critical hit, it rolls damage dice three times, instead of twice."
+           :damage :slashing
+           :dice "3d8+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-balor/whip]
+          {:id :creatures-balor/whip
+           :name "Whip"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 30 ft., one target. _Hit: _15 (2d6 + 8) slashing damage plus 10 (3d6) fire damage, and the target must succeed on a DC 20 Strength saving throw or be pulled up to 25 feet toward the balor."
+           :damage :slashing
+           :dice "2d6+8"
+           :to-hit 14})
+        (provide-feature
+          {:id :creatures-balor/teleport
+           :name "Teleport"
+           :desc "The balor magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."}))}
+  {:id :creatures/dretch
+   :name "Dretch"
+   :ac 11
+   :challenge 0.25
+   :hit-points "4d6 + 4"
+   :abilities {:str 11 :dex 11 :con 12 :int 5 :wis 8 :cha 3}
+   :senses "darkvision 60 ft., passive Perception 9"
+   :size :small
+   :type :fiend
+   :speed "20 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-dretch/multiattack]
+          {:id :creatures-dretch/multiattack
+           :name "Multiattack"
+           :desc "The dretch makes two attacks: one with its bite and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-dretch/bite]
+          {:id :creatures-dretch/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _3 (1d6) piercing damage."
+           :damage :piercing
+           :dice "1d6"
+           :to-hit 2})
+        (provide-attr
+          [:attacks :creatures-dretch/claws]
+          {:id :creatures-dretch/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _5 (2d4) slashing damage."
+           :damage :slashing
+           :dice "2d4"
+           :to-hit 2})
+        (provide-feature
+          {:id :creatures-dretch/fetid-cloud
+           :name "Fetid Cloud (1/Day)"
+           :desc "A 10-foot radius of disgusting green gas extends out from the dretch. The gas spreads around corners, and its area is lightly obscured. It lasts for 1 minute or until a strong wind disperses it. Any creature that starts its turn in that area must succeed on a DC 11 Constitution saving throw or be poisoned until the start of its next turn. While poisoned in this way, the target can take either an action or a bonus action on its turn, not both, and can’t take reactions."}))}
+  {:id :creatures/glabrezu
+   :name "Glabrezu"
+   :ac 17
+   :challenge 9
+   :hit-points "15d10 + 75"
+   :abilities {:str 20 :dex 15 :con 21 :int 19 :wis 17 :cha 16}
+   :senses "truesight 120 ft., passive Perception 13"
+   :size :large
+   :type :fiend
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-glabrezu/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The glabrezu’s spellcasting ability is Intelligence (spell save DC 16). The glabrezu can innately cast the following spells, requiring no material components:"})
+        (provide-feature
+          {:id :creatures-glabrezu/magic-resistance
+           :name "Magic Resistance"
+           :desc "The glabrezu has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-glabrezu/multiattack]
+          {:id :creatures-glabrezu/multiattack
+           :name "Multiattack"
+           :desc "The glabrezu makes four attacks: two with its pincers and two with its fists. Alternatively, it makes two attacks with its pincers and casts one spell."})
+        (provide-attr
+          [:attacks :creatures-glabrezu/pincer]
+          {:id :creatures-glabrezu/pincer
+           :name "Pincer"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 10 ft., one target. _Hit: _16 (2d10 + 5) bludgeoning damage. If the target is a Medium or smaller creature, it is grappled (escape DC 15). The glabrezu has two pincers, each of which can grapple only one target."
+           :damage :bludgeoning
+           :dice "2d10+5"
+           :to-hit 9})
+        (provide-attr
+          [:attacks :creatures-glabrezu/fist]
+          {:id :creatures-glabrezu/fist
+           :name "Fist"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one target. _Hit: _7 (2d4 + 2) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d4+2"
+           :to-hit 9}))}
+  {:id :creatures/hezrou
+   :name "Hezrou"
+   :ac 16
+   :challenge 8
+   :hit-points "13d10 + 65"
+   :abilities {:str 19 :dex 17 :con 20 :int 5 :wis 12 :cha 13}
+   :senses "darkvision 120 ft., passive Perception 11"
+   :size :large
+   :type :fiend
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-hezrou/magic-resistance
+           :name "Magic Resistance"
+           :desc "The hezrou has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-hezrou/stench
+           :name "Stench"
+           :desc "Any creature that starts its turn within 10 feet of the hezrou must succeed on a DC 14 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the hezrou’s stench for 24 hours."})
+        (provide-attr
+          [:attacks :creatures-hezrou/multiattack]
+          {:id :creatures-hezrou/multiattack
+           :name "Multiattack"
+           :desc "The hezrou makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-hezrou/bite]
+          {:id :creatures-hezrou/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _15 (2d10 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d10+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-hezrou/claw]
+          {:id :creatures-hezrou/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 7}))}
+  {:id :creatures/marilith
+   :name "Marilith"
+   :ac 18
+   :challenge 16
+   :hit-points "18d10 + 90"
+   :abilities {:str 18 :dex 20 :con 20 :int 18 :wis 16 :cha 20}
+   :senses "truesight 120 ft., passive Perception 13"
+   :size :large
+   :type :fiend
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-marilith/magic-resistance
+           :name "Magic Resistance"
+           :desc "The marilith has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-marilith/magic-weapons
+           :name "Magic Weapons"
+           :desc "The marilith’s weapon attacks are magical."})
+        (provide-feature
+          {:id :creatures-marilith/reactive
+           :name "Reactive"
+           :desc "The marilith can take one reaction on every turn in a combat."})
+        (provide-attr
+          [:attacks :creatures-marilith/multiattack]
+          {:id :creatures-marilith/multiattack
+           :name "Multiattack"
+           :desc "The marilith makes seven attacks: six with its longswords and one with its tail."})
+        (provide-attr
+          [:attacks :creatures-marilith/longsword]
+          {:id :creatures-marilith/longsword
+           :name "Longsword"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d8+4"
+           :to-hit 9})
+        (provide-attr
+          [:attacks :creatures-marilith/tail]
+          {:id :creatures-marilith/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 10 ft., one creature. _Hit: _15 (2d10 + 4) bludgeoning damage. If the target is Medium or smaller, it is grappled (escape DC 19). Until this grapple ends, the target is restrained, the marilith can automatically hit the target with its tail, and the marilith can’t make tail attacks against other targets."
+           :damage :bludgeoning
+           :dice "2d10+4"
+           :to-hit 9})
+        (provide-feature
+          {:id :creatures-marilith/teleport
+           :name "Teleport"
+           :desc "The marilith magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."})
+        (provide-feature
+          {:id :creatures-marilith/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-marilith/parry
+           :name "Parry"
+           :desc "The marilith adds 5 to its AC against one melee attack that would hit it. To do so, the marilith must see the attacker and be wielding a melee weapon."}))}
+  {:id :creatures/nalfeshnee
+   :name "Nalfeshnee"
+   :ac 18
+   :challenge 13
+   :hit-points "16d10 + 96"
+   :abilities {:str 21 :dex 10 :con 22 :int 19 :wis 12 :cha 15}
+   :senses "truesight 120 ft., passive Perception 11"
+   :size :large
+   :type :fiend
+   :speed "20 ft., fly 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-nalfeshnee/magic-resistance
+           :name "Magic Resistance"
+           :desc "The nalfeshnee has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-nalfeshnee/multiattack]
+          {:id :creatures-nalfeshnee/multiattack
+           :name "Multiattack"
+           :desc "The nalfeshnee uses Horror Nimbus if it can. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-nalfeshnee/bite]
+          {:id :creatures-nalfeshnee/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one target. _Hit: _32 (5d10 + 5) piercing damage."
+           :damage :piercing
+           :dice "5d10+5"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-nalfeshnee/claw]
+          {:id :creatures-nalfeshnee/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _15 (3d6 + 5) slashing damage."
+           :damage :slashing
+           :dice "3d6+5"
+           :to-hit 10})
+        (provide-feature
+          {:id :creatures-nalfeshnee/horror-nimbus
+           :name "Horror Nimbus (Recharge 5–6)"
+           :desc "The nalfeshnee magically emits scintillating, multicolored light. Each creature within 15 feet of the nalfeshnee that can see the light must succeed on a DC 15 Wisdom saving throw or be frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the nalfeshnee’s Horror Nimbus for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-nalfeshnee/teleport
+           :name "Teleport"
+           :desc "The nalfeshnee magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."}))}
+  {:id :creatures/quasit
+   :name "Quasit"
+   :ac 13
+   :challenge 1
+   :hit-points "3d4"
+   :abilities {:str 5 :dex 17 :con 10 :int 7 :wis 10 :cha 10}
+   :senses "darkvision 120 ft., passive Perception 10"
+   :size :tiny
+   :type :fiend
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-quasit/shapechanger
+           :name "Shapechanger"
+           :desc "The quasit can use its action to polymorph into a beast form that resembles a bat (speed 10 ft. fly 40 ft.), a centipede (40 ft., climb 40 ft.), or a toad (40 ft., swim 40 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-feature
+          {:id :creatures-quasit/magic-resistance
+           :name "Magic Resistance"
+           :desc "The quasit has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-quasit/claws]
+          {:id :creatures-quasit/claws
+           :name "Claws (Bite in Beast Form)"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d4 + 3) piercing damage, and the target must succeed on a DC 10 Constitution saving throw or take 5 (2d4) poison damage and become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+           :damage :piercing
+           :dice "1d4+3"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-quasit/scare
+           :name "Scare (1/Day)"
+           :desc "One creature of the quasit’s choice within 20 feet of it must succeed on a DC 10 Wisdom saving throw or be frightened for 1 minute. The target can repeat the saving throw at the end of each of its turns, with disadvantage if the quasit is within line of sight, ending the effect on itself on a success."})
+        (provide-feature
+          {:id :creatures-quasit/invisibility
+           :name "Invisibility"
+           :desc "The quasit magically turns invisible until it attacks or uses Scare, or until its concentration ends (as if concentrating on a spell). Any equipment the quasit wears or carries is invisible with it."}))}
+  {:id :creatures/vrock
+   :name "Vrock"
+   :ac 15
+   :challenge 6
+   :hit-points "11d10 + 44"
+   :abilities {:str 17 :dex 15 :con 18 :int 8 :wis 13 :cha 8}
+   :senses "darkvision 120 ft., passive Perception 11"
+   :size :large
+   :type :fiend
+   :speed "40 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-vrock/magic-resistance
+           :name "Magic Resistance"
+           :desc "The vrock has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-vrock/multiattack]
+          {:id :creatures-vrock/multiattack
+           :name "Multiattack"
+           :desc "The vrock makes two attacks: one with its beak and one with its talons."})
+        (provide-attr
+          [:attacks :creatures-vrock/beak]
+          {:id :creatures-vrock/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "2d6+3"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-vrock/talons]
+          {:id :creatures-vrock/talons
+           :name "Talons"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _14 (2d10 + 3) slashing damage."
+           :damage :slashing
+           :dice "2d10+3"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-vrock/spores
+           :name "Spores (Recharge 6)"
+           :desc "A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must succeed on a DC 14 Constitution saving throw or become poisoned. While poisoned in this way, a target takes 5 (1d10) poison damage at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a vial of holy water on the target also ends the effect on it."})
+        (provide-feature
+          {:id :creatures-vrock/stunning-screech
+           :name "Stunning Screech (1/Day)"
+           :desc "The vrock emits a horrific screech. Each creature within 20 feet of it that can hear it and that isn’t a demon must succeed on a DC 14 Constitution saving throw or be stunned until the end of the vrock’s next turn."}))}
+  {:id :creatures/barbed-devil
+   :name "Barbed Devil"
+   :ac 15
+   :challenge 5
+   :hit-points "13d8 + 52"
+   :abilities {:str 16 :dex 17 :con 18 :int 12 :wis 14 :cha 14}
+   :senses "darkvision 120 ft., passive Perception 18"
+   :size :medium
+   :type :fiend
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-barbed-devil/barbed-hide
+           :name "Barbed Hide"
+           :desc "At the start of each of its turns, the barbed devil deals 5 (1d10) piercing damage to any creature grappling it."})
+        (provide-feature
+          {:id :creatures-barbed-devil/devil-s-sight
+           :name "Devil’s Sight"
+           :desc "Magical darkness doesn’t impede the devil’s darkvision."})
+        (provide-feature
+          {:id :creatures-barbed-devil/magic-resistance
+           :name "Magic Resistance"
+           :desc "The devil has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-barbed-devil/multiattack]
+          {:id :creatures-barbed-devil/multiattack
+           :name "Multiattack"
+           :desc "The devil makes three melee attacks: one with its tail and two with its claws. Alternatively, it can use Hurl Flame twice."})
+        (provide-attr
+          [:attacks :creatures-barbed-devil/claw]
+          {:id :creatures-barbed-devil/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d6+3"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-barbed-devil/tail]
+          {:id :creatures-barbed-devil/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "2d6+3"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-barbed-devil/hurl-flame]
+          {:id :creatures-barbed-devil/hurl-flame
+           :name "Hurl Flame"
+           :desc "_Ranged Spell Attack: _+5 to hit, range 150 ft., one target. _Hit: _10 (3d6) fire damage. If the target is a flammable object that isn’t being worn or carried, it also catches fire."
+           :damage :fire
+           :dice "3d6"
+           :to-hit 5}))}
+  {:id :creatures/bearded-devil
+   :name "Bearded Devil"
+   :ac 13
+   :challenge 3
+   :hit-points "8d8 + 16"
+   :abilities {:str 16 :dex 15 :con 15 :int 9 :wis 11 :cha 11}
+   :senses "darkvision 120 ft., passive Perception 10"
+   :size :medium
+   :type :fiend
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-bearded-devil/devil-s-sight
+           :name "Devil’s Sight"
+           :desc "Magical darkness doesn’t impede the devil’s darkvision."})
+        (provide-feature
+          {:id :creatures-bearded-devil/magic-resistance
+           :name "Magic Resistance"
+           :desc "The devil has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-bearded-devil/steadfast
+           :name "Steadfast"
+           :desc "The devil can’t be frightened while it can see an allied creature within 30 feet of it."})
+        (provide-attr
+          [:attacks :creatures-bearded-devil/multiattack]
+          {:id :creatures-bearded-devil/multiattack
+           :name "Multiattack"
+           :desc "The devil makes two attacks: one with its beard and one with its glaive."})
+        (provide-attr
+          [:attacks :creatures-bearded-devil/beard]
+          {:id :creatures-bearded-devil/beard
+           :name "Beard"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one creature. _Hit: _6 (1d8 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. While poisoned in this way, the target can’t regain hit points. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-bearded-devil/glaive]
+          {:id :creatures-bearded-devil/glaive
+           :name "Glaive"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 10 ft., one target. _Hit: _8 (1d10 + 3) slashing damage. If the target is a creature other than an undead or a construct, it must succeed on a DC 12 Constitution saving throw or lose 5 (1d10) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 5 (1d10). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+           :damage :slashing
+           :dice "1d10+3"
+           :to-hit 5}))}
+  {:id :creatures/bone-devil
+   :name "Bone Devil"
+   :ac 19
+   :challenge 9
+   :hit-points "15d10 + 60"
+   :abilities {:str 18 :dex 16 :con 18 :int 13 :wis 14 :cha 16}
+   :senses "darkvision 120 ft., passive Perception 12"
+   :size :large
+   :type :fiend
+   :speed "40 ft., fly 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-bone-devil/devil-s-sight
+           :name "Devil’s Sight"
+           :desc "Magical darkness doesn’t impede the devil’s darkvision."})
+        (provide-feature
+          {:id :creatures-bone-devil/magic-resistance
+           :name "Magic Resistance"
+           :desc "The devil has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-bone-devil/multiattack]
+          {:id :creatures-bone-devil/multiattack
+           :name "Multiattack"
+           :desc "The devil makes three attacks: two with its claws and one with its sting."})
+        (provide-attr
+          [:attacks :creatures-bone-devil/claw]
+          {:id :creatures-bone-devil/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 10 ft., one target. _Hit: _8 (1d8 + 4) slashing damage."
+           :damage :slashing
+           :dice "1d8+4"
+           :to-hit 8})
+        (provide-attr
+          [:attacks :creatures-bone-devil/sting]
+          {:id :creatures-bone-devil/sting
+           :name "Sting"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 10 ft., one target. _Hit: _13 (2d8 + 4) piercing damage plus 17 (5d6) poison damage, and the target must succeed on a DC 14 Constitution saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+           :damage :piercing
+           :dice "2d8+4"
+           :to-hit 8}))}
+  {:id :creatures/chain-devil
+   :name "Chain Devil"
+   :ac 16
+   :challenge 8
+   :hit-points "10d8 + 40"
+   :abilities {:str 18 :dex 15 :con 18 :int 11 :wis 12 :cha 14}
+   :senses "darkvision 120 ft., passive Perception 11"
+   :size :medium
+   :type :fiend
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-chain-devil/devil-s-sight
+           :name "Devil’s Sight"
+           :desc "Magical darkness doesn’t impede the devil’s darkvision."})
+        (provide-feature
+          {:id :creatures-chain-devil/magic-resistance
+           :name "Magic Resistance"
+           :desc "The devil has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-chain-devil/multiattack]
+          {:id :creatures-chain-devil/multiattack
+           :name "Multiattack"
+           :desc "The devil makes two attacks with its chains."})
+        (provide-attr
+          [:attacks :creatures-chain-devil/chain]
+          {:id :creatures-chain-devil/chain
+           :name "Chain"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 10 ft., one target. _Hit: _11 (2d6 + 4) slashing damage. The target is grappled (escape DC 14) if the devil isn’t already grappling a creature. Until this grapple ends, the target is restrained and takes 7 (2d6) piercing damage at the start of each of its turns."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 8})
+        (provide-feature
+          {:id :creatures-chain-devil/animate-chains
+           :name "Animate Chains (Recharges after a Short or Long Rest)"
+           :desc "Up to four chains the devil can see within 60 feet of it magically sprout razor-edged barbs and animate under the devil’s control, provided that the chains aren’t being worn or carried."})
+        (provide-feature
+          {:id :creatures-chain-devil/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-chain-devil/unnerving-mask
+           :name "Unnerving Mask"
+           :desc "When a creature the devil can see starts its turn within 30 feet of the devil, the devil can create the illusion that it looks like one of the creature’s departed loved ones or bitter enemies. If the creature can see the devil, it must succeed on a DC 14 Wisdom saving throw or be frightened until the end of its turn."}))}
+  {:id :creatures/erinyes
+   :name "Erinyes"
+   :ac 18
+   :challenge 12
+   :hit-points "18d8 + 72"
+   :abilities {:str 18 :dex 16 :con 18 :int 14 :wis 14 :cha 18}
+   :senses "truesight 120 ft., passive Perception 12"
+   :size :medium
+   :type :fiend
+   :speed "30 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-erinyes/hellish-weapons
+           :name "Hellish Weapons"
+           :desc "The erinyes’s weapon attacks are magical and deal an extra 13 (3d8) poison damage on a hit (included in the attacks)."})
+        (provide-feature
+          {:id :creatures-erinyes/magic-resistance
+           :name "Magic Resistance"
+           :desc "The erinyes has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-erinyes/multiattack]
+          {:id :creatures-erinyes/multiattack
+           :name "Multiattack"
+           :desc "The erinyes makes three attacks."})
+        (provide-attr
+          [:attacks :creatures-erinyes/longsword]
+          {:id :creatures-erinyes/longsword
+           :name "Longsword"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _8 (1d8 + 4) slashing damage, or 9 (1d10 + 4) slashing damage if used with two hands, plus 13 (3d8) poison damage."
+           :damage :slashing
+           :dice "1d8+4"
+           :to-hit 8})
+        (provide-attr
+          [:attacks :creatures-erinyes/longbow]
+          {:id :creatures-erinyes/longbow
+           :name "Longbow"
+           :desc "_Ranged Weapon Attack: _+7 to hit, range 150/600 ft., one target. _Hit: _7 (1d8 + 3) piercing damage plus 13 (3d8) poison damage, and the target must succeed on a DC 14 Constitution saving throw or be poisoned. The poison lasts until it is removed by the _lesser restoration _spell or similar magic."
+           :damage :piercing
+           :dice "1d8+3"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-erinyes/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-erinyes/parry
+           :name "Parry"
+           :desc "The erinyes adds 4 to its AC against one melee attack that would hit it. To do so, the erinyes must see the attacker and be wielding a melee weapon."}))}
+  {:id :creatures/horned-devil
+   :name "Horned Devil"
+   :ac 18
+   :challenge 11
+   :hit-points "17d10 + 85"
+   :abilities {:str 22 :dex 17 :con 21 :int 12 :wis 16 :cha 17}
+   :senses "darkvision 120 ft., passive Perception 13"
+   :size :large
+   :type :fiend
+   :speed "20 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-horned-devil/devil-s-sight
+           :name "Devil’s Sight"
+           :desc "Magical darkness doesn’t impede the devil’s darkvision."})
+        (provide-feature
+          {:id :creatures-horned-devil/magic-resistance
+           :name "Magic Resistance"
+           :desc "The devil has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-horned-devil/multiattack]
+          {:id :creatures-horned-devil/multiattack
+           :name "Multiattack"
+           :desc "The devil makes three melee attacks: two with its fork and one with its tail. It can use Hurl Flame in place of any melee attack."})
+        (provide-attr
+          [:attacks :creatures-horned-devil/fork]
+          {:id :creatures-horned-devil/fork
+           :name "Fork"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _15 (2d8 + 6) piercing damage."
+           :damage :piercing
+           :dice "2d8+6"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-horned-devil/tail]
+          {:id :creatures-horned-devil/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _10 (1d8 + 6) piercing damage. If the target is a creature other than an undead or a construct, it must succeed on a DC 17 Constitution saving throw or lose 10 (3d6) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 10 (3d6). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+           :damage :piercing
+           :dice "1d8+6"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-horned-devil/hurl-flame]
+          {:id :creatures-horned-devil/hurl-flame
+           :name "Hurl Flame"
+           :desc "_Ranged Spell Attack: _+7 to hit, range 150 ft., one target. _Hit: _14 (4d6) fire damage. If the target is a flammable object that isn’t being worn or carried, it also catches fire."
+           :damage :fire
+           :dice "4d6"
+           :to-hit 7}))}
+  {:id :creatures/ice-devil
+   :name "Ice Devil"
+   :ac 18
+   :challenge 14
+   :hit-points "19d10 + 76"
+   :abilities {:str 21 :dex 14 :con 18 :int 18 :wis 15 :cha 18}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 12"
+   :size :large
+   :type :fiend
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ice-devil/devil-s-sight
+           :name "Devil’s Sight"
+           :desc "Magical darkness doesn’t impede the devil’s darkvision."})
+        (provide-feature
+          {:id :creatures-ice-devil/magic-resistance
+           :name "Magic Resistance"
+           :desc "The devil has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-ice-devil/multiattack]
+          {:id :creatures-ice-devil/multiattack
+           :name "Multiattack"
+           :desc "The devil makes three attacks: one with its bite, one with its claws, and one with its tail."})
+        (provide-attr
+          [:attacks :creatures-ice-devil/bite]
+          {:id :creatures-ice-devil/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one target. _Hit: _12 (2d6 + 5) piercing damage plus 10 (3d6) cold damage."
+           :damage :piercing
+           :dice "2d6+5"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-ice-devil/claws]
+          {:id :creatures-ice-devil/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one target. _Hit: _10 (2d4 + 5) slashing damage plus 10 (3d6) cold damage."
+           :damage :slashing
+           :dice "2d4+5"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-ice-devil/tail]
+          {:id :creatures-ice-devil/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _12 (2d6 + 5) bludgeoning damage plus 10 (3d6) cold damage."
+           :damage :bludgeoning
+           :dice "2d6+5"
+           :to-hit 10})
+        (provide-feature
+          {:id :creatures-ice-devil/wall-of-ice
+           :name "Wall of Ice (Recharge 6)"
+           :desc "The devil magically forms an opaque wall of ice on a solid surface it can see within 60 feet of it. The wall is 1 foot thick and up to 30 feet long and 10 feet high, or it’s a hemispherical dome up to 20 feet in diameter."}))}
+  {:id :creatures/imp
+   :name "Imp"
+   :ac 13
+   :challenge 1
+   :hit-points "3d4 + 3"
+   :abilities {:str 6 :dex 17 :con 13 :int 11 :wis 12 :cha 14}
+   :senses "darkvision 120 ft., passive Perception 11"
+   :size :tiny
+   :type :fiend
+   :speed "20 ft., fly 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-imp/shapechanger
+           :name "Shapechanger"
+           :desc "The imp can use its action to polymorph into a beast form that resembles a rat (speed 20 ft.), a raven (20 ft., fly 60 ft.), or a spider (20 ft., climb 20 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-feature
+          {:id :creatures-imp/devil-s-sight
+           :name "Devil’s Sight"
+           :desc "Magical darkness doesn’t impede the imp’s darkvision."})
+        (provide-feature
+          {:id :creatures-imp/magic-resistance
+           :name "Magic Resistance"
+           :desc "The imp has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-imp/sting]
+          {:id :creatures-imp/sting
+           :name "Sting (Bite in Beast Form)"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _5 (1d4 + 3) piercing damage, and the target must make on a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :piercing
+           :dice "1d4+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-imp/invisibility
+           :name "Invisibility"
+           :desc "The imp magically turns invisible until it attacks or until its concentration ends (as if concentrating on a spell). Any equipment the imp wears or carries is invisible with it."}))}
+  {:id :creatures/lemure
+   :name "Lemure"
+   :ac 7
+   :challenge 0
+   :hit-points "3d8"
+   :abilities {:str 10 :dex 5 :con 11 :int 1 :wis 11 :cha 3}
+   :senses "darkvision 120 ft., passive Perception 10"
+   :size :medium
+   :type :fiend
+   :speed "15 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-lemure/devil-s-sight
+           :name "Devil’s Sight"
+           :desc "Magical darkness doesn’t impede the lemure’s darkvision."})
+        (provide-feature
+          {:id :creatures-lemure/hellish-rejuvenation
+           :name "Hellish Rejuvenation"
+           :desc "A lemure that dies in the Nine Hells comes back to life with all its hit points in 1d10 days unless it is killed by a good-aligned creature with a _bless _spell cast on that creature or its remains are sprinkled with holy water."})
+        (provide-attr
+          [:attacks :creatures-lemure/fist]
+          {:id :creatures-lemure/fist
+           :name "Fist"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _2 (1d4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d4"
+           :to-hit 3}))}
+  {:id :creatures/pit-fiend
+   :name "Pit Fiend"
+   :ac 19
+   :challenge 20
+   :hit-points "24d10 + 168"
+   :abilities {:str 26 :dex 14 :con 24 :int 22 :wis 18 :cha 24}
+   :senses "truesight 120 ft., passive Perception 14"
+   :size :large
+   :type :fiend
+   :speed "30 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-pit-fiend/fear-aura
+           :name "Fear Aura"
+           :desc "Any creature hostile to the pit fiend that starts its turn within 20 feet of the pit fiend must make a DC 21 Wisdom saving throw, unless the pit fiend is incapacitated. On a failed save, the creature is frightened until the start of its next turn. If a creature’s saving throw is successful, the creature is immune to the pit fiend’s Fear Aura for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-pit-fiend/magic-resistance
+           :name "Magic Resistance"
+           :desc "The pit fiend has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-pit-fiend/magic-weapons
+           :name "Magic Weapons"
+           :desc "The pit fiend’s weapon attacks are magical."})
+        (provide-feature
+          {:id :creatures-pit-fiend/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The pit fiend’s spellcasting ability is Charisma (spell save DC 21). The pit fiend can innately cast the following spells, requiring no material components:"})
+        (provide-attr
+          [:attacks :creatures-pit-fiend/multiattack]
+          {:id :creatures-pit-fiend/multiattack
+           :name "Multiattack"
+           :desc "The pit fiend makes four attacks: one with its bite, one with its claw, one with its mace, and one with its tail."})
+        (provide-attr
+          [:attacks :creatures-pit-fiend/bite]
+          {:id :creatures-pit-fiend/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 5 ft., one target. _Hit: _22 (4d6 + 8) piercing damage. The target must succeed on a DC 21 Constitution saving throw or become poisoned. While poisoned in this way, the target can’t regain hit points, and it takes 21 (6d6) poison damage at the start of each of its turns. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+           :damage :piercing
+           :dice "4d6+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-pit-fiend/claw]
+          {:id :creatures-pit-fiend/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 10 ft., one target. _Hit: _17 (2d8 + 8) slashing damage."
+           :damage :slashing
+           :dice "2d8+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-pit-fiend/mace]
+          {:id :creatures-pit-fiend/mace
+           :name "Mace"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 10 ft., one target. _Hit: _15 (2d6 + 8) bludgeoning damage plus 21 (6d6) fire damage."
+           :damage :bludgeoning
+           :dice "2d6+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-pit-fiend/tail]
+          {:id :creatures-pit-fiend/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 10 ft., one target. _Hit: _24 (3d10 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d10+8"
+           :to-hit 14}))}
+  {:id :creatures/plesiosaurus
+   :name "Plesiosaurus"
+   :ac 13
+   :challenge 2
+   :hit-points "8d10 + 24"
+   :abilities {:str 18 :dex 15 :con 16 :int 2 :wis 12 :cha 5}
+   :senses "passive Perception 13"
+   :size :large
+   :type :beast
+   :speed "20 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-plesiosaurus/hold-breath
+           :name "Hold Breath"
+           :desc "The plesiosaurus can hold its breath for 1 hour."})
+        (provide-attr
+          [:attacks :creatures-plesiosaurus/bite]
+          {:id :creatures-plesiosaurus/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one target. _Hit: _14 (3d6 + 4) piercing damage."
+           :damage :piercing
+           :dice "3d6+4"
+           :to-hit 6}))}
+  {:id :creatures/triceratops
+   :name "Triceratops"
+   :ac 13
+   :challenge 5
+   :hit-points "10d12 + 30"
+   :abilities {:str 22 :dex 9 :con 17 :int 2 :wis 11 :cha 5}
+   :senses "passive Perception 10"
+   :size :huge
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-triceratops/trampling-charge
+           :name "Trampling Charge"
+           :desc "If the triceratops moves at least 20 feet straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the triceratops can make one stomp attack against it as a bonus action."})
+        (provide-attr
+          [:attacks :creatures-triceratops/gore]
+          {:id :creatures-triceratops/gore
+           :name "Gore"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one target. _Hit: _24 (4d8 + 6) piercing damage."
+           :damage :piercing
+           :dice "4d8+6"
+           :to-hit 9})
+        (provide-attr
+          [:attacks :creatures-triceratops/stomp]
+          {:id :creatures-triceratops/stomp
+           :name "Stomp"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one prone creature. _Hit: _22 (3d10 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d10+6"
+           :to-hit 9}))}
+  {:id :creatures/tyrannosaurus-rex
+   :name "Tyrannosaurus Rex"
+   :ac 13
+   :challenge 8
+   :hit-points "13d12 + 52"
+   :abilities {:str 25 :dex 10 :con 19 :int 2 :wis 12 :cha 9}
+   :senses "passive Perception 14"
+   :size :huge
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-tyrannosaurus-rex/multiattack]
+          {:id :creatures-tyrannosaurus-rex/multiattack
+           :name "Multiattack"
+           :desc "The tyrannosaurus makes two attacks: one with its bite and one with its tail. It can’t make both attacks against the same target."})
+        (provide-attr
+          [:attacks :creatures-tyrannosaurus-rex/bite]
+          {:id :creatures-tyrannosaurus-rex/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _33 (4d12 + 7) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the tyrannosaurus can’t bite another target."
+           :damage :piercing
+           :dice "4d12+7"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-tyrannosaurus-rex/tail]
+          {:id :creatures-tyrannosaurus-rex/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _20 (3d8 + 7) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d8+7"
+           :to-hit 10}))}
+  {:id :creatures/doppelganger
+   :name "Doppelganger"
+   :ac 14
+   :challenge 3
+   :hit-points "8d8 + 16"
+   :abilities {:str 11 :dex 18 :con 14 :int 11 :wis 12 :cha 14}
+   :senses "darkvision 60 ft., passive Perception 11"
+   :size :medium
+   :type :monstrosity
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-doppelganger/shapechanger
+           :name "Shapechanger"
+           :desc "The doppelganger can use its action to polymorph into a Small or Medium humanoid it has seen, or back into its true form. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-feature
+          {:id :creatures-doppelganger/ambusher
+           :name "Ambusher"
+           :desc "In the first round of a combat, the doppelganger has advantage on attack rolls against any creature it has surprised."})
+        (provide-feature
+          {:id :creatures-doppelganger/surprise-attack
+           :name "Surprise Attack"
+           :desc "If the doppelganger surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 10 (3d6) damage from the attack."})
+        (provide-attr
+          [:attacks :creatures-doppelganger/multiattack]
+          {:id :creatures-doppelganger/multiattack
+           :name "Multiattack"
+           :desc "The doppelganger makes two melee attacks."})
+        (provide-attr
+          [:attacks :creatures-doppelganger/slam]
+          {:id :creatures-doppelganger/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _7 (1d6 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6+4"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-doppelganger/read-thoughts
+           :name "Read Thoughts"
+           :desc "The doppelganger magically reads the surface thoughts of one creature within 60 feet of it. The effect can penetrate barriers, but 3 feet of wood or dirt, 2 feet of stone, 2 inches of metal, or a thin sheet of lead blocks it. While the target is in range, the doppelganger can continue reading its thoughts, as long as the doppelganger’s concentration isn’t broken (as if concentrating on a spell). While reading the target’s mind, the doppelganger has advantage on Wisdom (Insight) and Charisma (Deception, Intimidation, and Persuasion) checks against the target."}))}
+  {:id :creatures/ancient-black-dragon
+   :name "Ancient Black Dragon"
+   :ac 22
+   :challenge 21
+   :hit-points "21d20 + 147"
+   :abilities {:str 27 :dex 14 :con 25 :int 16 :wis 15 :cha 19}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 26"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-black-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-feature
+          {:id :creatures-ancient-black-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-black-dragon/multiattack]
+          {:id :creatures-ancient-black-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-black-dragon/bite]
+          {:id :creatures-ancient-black-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 15 ft., one target. _Hit: _19 (2d10 + 8) piercing damage plus 9 (2d8) acid damage."
+           :damage :piercing
+           :dice "2d10+8"
+           :to-hit 15})
+        (provide-attr
+          [:attacks :creatures-ancient-black-dragon/claw]
+          {:id :creatures-ancient-black-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 10 ft., one target. _Hit: _15 (2d6 + 8) slashing damage."
+           :damage :slashing
+           :dice "2d6+8"
+           :to-hit 15})
+        (provide-attr
+          [:attacks :creatures-ancient-black-dragon/tail]
+          {:id :creatures-ancient-black-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 20 ft., one target. _Hit: _17 (2d8 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+8"
+           :to-hit 15})
+        (provide-feature
+          {:id :creatures-ancient-black-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-black-dragon/acid-breath
+           :name "Acid Breath (Recharge 5–6)"
+           :desc "The dragon exhales acid in a 90-foot line that is 10 feet wide. Each creature in that line must make a DC 22 Dexterity saving throw, taking 67 (15d8) acid damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-black-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-black-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-black-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-black-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-black-dragon
+   :name "Adult Black Dragon"
+   :ac 19
+   :challenge 14
+   :hit-points "17d12 + 85"
+   :abilities {:str 23 :dex 14 :con 21 :int 14 :wis 13 :cha 17}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 21"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-black-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-feature
+          {:id :creatures-adult-black-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-black-dragon/multiattack]
+          {:id :creatures-adult-black-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence."})
+        (provide-attr
+          [:attacks :creatures-adult-black-dragon/bite]
+          {:id :creatures-adult-black-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 10 ft., one target. _Hit: _17 (2d10 + 6) piercing damage plus 4 (1d8) acid damage."
+           :damage :piercing
+           :dice "2d10+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-black-dragon/claw]
+          {:id :creatures-adult-black-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 5 ft., one target. _Hit: _13 (2d6 + 6) slashing damage."
+           :damage :slashing
+           :dice "2d6+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-black-dragon/tail]
+          {:id :creatures-adult-black-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 15 ft., one target. _Hit: _15 (2d8 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+6"
+           :to-hit 11})
+        (provide-feature
+          {:id :creatures-adult-black-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-black-dragon/acid-breath
+           :name "Acid Breath (Recharge 5–6)"
+           :desc "The dragon exhales acid in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-black-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-black-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-black-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-black-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-black-dragon
+   :name "Young Black Dragon"
+   :ac 18
+   :challenge 7
+   :hit-points "15d10 + 45"
+   :abilities {:str 19 :dex 14 :con 17 :int 12 :wis 11 :cha 15}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 16"
+   :size :large
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-young-black-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-young-black-dragon/multiattack]
+          {:id :creatures-young-black-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-black-dragon/bite]
+          {:id :creatures-young-black-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one target. _Hit: _15 (2d10 + 4) piercing damage plus 4 (1d8) acid damage."
+           :damage :piercing
+           :dice "2d10+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-young-black-dragon/claw]
+          {:id :creatures-young-black-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-young-black-dragon/acid-breath
+           :name "Acid Breath (Recharge 5–6)"
+           :desc "The dragon exhales acid in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 49 (11d8) acid damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/black-dragon-wyrmling
+   :name "Black Dragon Wyrmling"
+   :ac 17
+   :challenge 2
+   :hit-points "6d8 + 6"
+   :abilities {:str 15 :dex 14 :con 13 :int 10 :wis 11 :cha 13}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., fly 60 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-black-dragon-wyrmling/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-black-dragon-wyrmling/bite]
+          {:id :creatures-black-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (1d10 + 2) piercing damage plus 2 (1d4) acid damage."
+           :damage :piercing
+           :dice "1d10+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-black-dragon-wyrmling/acid-breath
+           :name "Acid Breath (Recharge 5–6)"
+           :desc "The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 22 (5d8) acid damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/ancient-blue-dragon
+   :name "Ancient Blue Dragon"
+   :ac 22
+   :challenge 23
+   :hit-points "26d20 + 208"
+   :abilities {:str 29 :dex 10 :con 27 :int 18 :wis 17 :cha 21}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 27"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., burrow 40 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-blue-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-blue-dragon/multiattack]
+          {:id :creatures-ancient-blue-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-blue-dragon/bite]
+          {:id :creatures-ancient-blue-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+16 to hit, reach 15 ft., one target. _Hit: _20 (2d10 + 9) piercing damage plus 11 (2d10) lightning damage."
+           :damage :piercing
+           :dice "2d10+9"
+           :to-hit 16})
+        (provide-attr
+          [:attacks :creatures-ancient-blue-dragon/claw]
+          {:id :creatures-ancient-blue-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+16 to hit, reach 10 ft., one target. _Hit: _16 (2d6 + 9) slashing damage."
+           :damage :slashing
+           :dice "2d6+9"
+           :to-hit 16})
+        (provide-attr
+          [:attacks :creatures-ancient-blue-dragon/tail]
+          {:id :creatures-ancient-blue-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+16 to hit, reach 20 ft., one target. _Hit: _18 (2d8 + 9) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+9"
+           :to-hit 16})
+        (provide-feature
+          {:id :creatures-ancient-blue-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 20 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-blue-dragon/lightning-breath
+           :name "Lightning Breath (Recharge 5–6)"
+           :desc "The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-blue-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-blue-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-blue-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-blue-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 24 Dexterity saving throw or take 16 (2d6 + 9) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-blue-dragon
+   :name "Adult Blue Dragon"
+   :ac 19
+   :challenge 16
+   :hit-points "18d12 + 108"
+   :abilities {:str 25 :dex 10 :con 23 :int 16 :wis 15 :cha 19}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 22"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., burrow 30 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-blue-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-blue-dragon/multiattack]
+          {:id :creatures-adult-blue-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-adult-blue-dragon/bite]
+          {:id :creatures-adult-blue-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+12 to hit, reach 10 ft., one target. _Hit: _18 (2d10 + 7) piercing damage plus 5 (1d10) lightning damage."
+           :damage :piercing
+           :dice "2d10+7"
+           :to-hit 12})
+        (provide-attr
+          [:attacks :creatures-adult-blue-dragon/claw]
+          {:id :creatures-adult-blue-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+12 to hit, reach 5 ft., one target. _Hit: _14 (2d6 + 7) slashing damage."
+           :damage :slashing
+           :dice "2d6+7"
+           :to-hit 12})
+        (provide-attr
+          [:attacks :creatures-adult-blue-dragon/tail]
+          {:id :creatures-adult-blue-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+12 to hit, reach 15 ft., one target. _Hit: _16 (2d8 + 7) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+7"
+           :to-hit 12})
+        (provide-feature
+          {:id :creatures-adult-blue-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-blue-dragon/lightning-breath
+           :name "Lightning Breath (Recharge 5–6)"
+           :desc "The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-blue-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-blue-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-blue-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-blue-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 20 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-blue-dragon
+   :name "Young Blue Dragon"
+   :ac 18
+   :challenge 9
+   :hit-points "16d10 + 64"
+   :abilities {:str 21 :dex 10 :con 19 :int 14 :wis 13 :cha 17}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 19"
+   :size :large
+   :type :dragon
+   :speed "40 ft., burrow 20 ft., fly 80 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-young-blue-dragon/multiattack]
+          {:id :creatures-young-blue-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-blue-dragon/bite]
+          {:id :creatures-young-blue-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 10 ft., one target. _Hit: _16 (2d10 + 5) piercing damage plus 5 (1d10) lightning damage."
+           :damage :piercing
+           :dice "2d10+5"
+           :to-hit 9})
+        (provide-attr
+          [:attacks :creatures-young-blue-dragon/claw]
+          {:id :creatures-young-blue-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one target. _Hit: _12 (2d6 + 5) slashing damage."
+           :damage :slashing
+           :dice "2d6+5"
+           :to-hit 9})
+        (provide-feature
+          {:id :creatures-young-blue-dragon/lightning-breath
+           :name "Lightning Breath (Recharge 5–6)"
+           :desc "The dragon exhales lightning in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/blue-dragon-wyrmling
+   :name "Blue Dragon Wyrmling"
+   :ac 17
+   :challenge 3
+   :hit-points "8d8 + 16"
+   :abilities {:str 17 :dex 10 :con 15 :int 12 :wis 11 :cha 15}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., burrow 15 ft., fly 60 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-blue-dragon-wyrmling/bite]
+          {:id :creatures-blue-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _8 (1d10 + 3) piercing damage plus 3 (1d6) lightning damage."
+           :damage :piercing
+           :dice "1d10+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-blue-dragon-wyrmling/lightning-breath
+           :name "Lightning Breath (Recharge 5–6)"
+           :desc "The dragon exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 22 (4d10) lightning damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/ancient-green-dragon
+   :name "Ancient Green Dragon"
+   :ac 21
+   :challenge 22
+   :hit-points "22d20 + 154"
+   :abilities {:str 27 :dex 12 :con 25 :int 20 :wis 17 :cha 19}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 27"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-green-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-feature
+          {:id :creatures-ancient-green-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-green-dragon/multiattack]
+          {:id :creatures-ancient-green-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-green-dragon/bite]
+          {:id :creatures-ancient-green-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 15 ft., one target. _Hit: _19 (2d10 + 8) piercing damage plus 10 (3d6) poison damage."
+           :damage :piercing
+           :dice "2d10+8"
+           :to-hit 15})
+        (provide-attr
+          [:attacks :creatures-ancient-green-dragon/claw]
+          {:id :creatures-ancient-green-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 10 ft., one target. _Hit: _22 (4d6 + 8) slashing damage."
+           :damage :slashing
+           :dice "4d6+8"
+           :to-hit 15})
+        (provide-attr
+          [:attacks :creatures-ancient-green-dragon/tail]
+          {:id :creatures-ancient-green-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 20 ft., one target. _Hit: _17 (2d8 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+8"
+           :to-hit 15})
+        (provide-feature
+          {:id :creatures-ancient-green-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-green-dragon/poison-breath
+           :name "Poison Breath (Recharge 5–6)"
+           :desc "The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 77 (22d6) poison damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-green-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-green-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-green-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-green-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-green-dragon
+   :name "Adult Green Dragon"
+   :ac 19
+   :challenge 15
+   :hit-points "18d12 + 90"
+   :abilities {:str 23 :dex 12 :con 21 :int 18 :wis 15 :cha 17}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 22"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-green-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-feature
+          {:id :creatures-adult-green-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-green-dragon/multiattack]
+          {:id :creatures-adult-green-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-adult-green-dragon/bite]
+          {:id :creatures-adult-green-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 10 ft., one target. _Hit: _17 (2d10 + 6) piercing damage plus 7 (2d6) poison damage."
+           :damage :piercing
+           :dice "2d10+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-green-dragon/claw]
+          {:id :creatures-adult-green-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 5 ft., one target. _Hit: _13 (2d6 + 6) slashing damage."
+           :damage :slashing
+           :dice "2d6+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-green-dragon/tail]
+          {:id :creatures-adult-green-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 15 ft., one target. _Hit: _15 (2d8 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+6"
+           :to-hit 11})
+        (provide-feature
+          {:id :creatures-adult-green-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-green-dragon/poison-breath
+           :name "Poison Breath (Recharge 5–6)"
+           :desc "The dragon exhales poisonous gas in a 60-foot cone. Each creature in that area must make a DC 18 Constitution saving throw, taking 56 (16d6) poison damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-green-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-green-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-green-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-green-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-green-dragon
+   :name "Young Green Dragon"
+   :ac 18
+   :challenge 8
+   :hit-points "16d10 + 48"
+   :abilities {:str 19 :dex 12 :con 17 :int 16 :wis 13 :cha 15}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 17"
+   :size :large
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-young-green-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-young-green-dragon/multiattack]
+          {:id :creatures-young-green-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-green-dragon/bite]
+          {:id :creatures-young-green-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one target. _Hit: _15 (2d10 + 4) piercing damage plus 7 (2d6) poison damage."
+           :damage :piercing
+           :dice "2d10+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-young-green-dragon/claw]
+          {:id :creatures-young-green-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-young-green-dragon/poison-breath
+           :name "Poison Breath (Recharge 5–6)"
+           :desc "The dragon exhales poisonous gas in a 30-foot cone. Each creature in that area must make a DC 14 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/green-dragon-wyrmling
+   :name "Green Dragon Wyrmling"
+   :ac 17
+   :challenge 2
+   :hit-points "7d8 + 7"
+   :abilities {:str 15 :dex 12 :con 13 :int 14 :wis 11 :cha 13}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., fly 60 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-green-dragon-wyrmling/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-green-dragon-wyrmling/bite]
+          {:id :creatures-green-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (1d10 + 2) piercing damage plus 3 (1d6) poison damage."
+           :damage :piercing
+           :dice "1d10+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-green-dragon-wyrmling/poison-breath
+           :name "Poison Breath (Recharge 5–6)"
+           :desc "The dragon exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 11 Constitution saving throw, taking 21 (6d6) poison damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/ancient-red-dragon
+   :name "Ancient Red Dragon"
+   :ac 22
+   :challenge 24
+   :hit-points "28d20 + 252"
+   :abilities {:str 30 :dex 10 :con 29 :int 18 :wis 15 :cha 23}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 26"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., climb 40 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-red-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-red-dragon/multiattack]
+          {:id :creatures-ancient-red-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-red-dragon/bite]
+          {:id :creatures-ancient-red-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+17 to hit, reach 15 ft., one target. _Hit: _21 (2d10 + 10) piercing damage plus 14 (4d6) fire damage."
+           :damage :piercing
+           :dice "2d10+10"
+           :to-hit 17})
+        (provide-attr
+          [:attacks :creatures-ancient-red-dragon/claw]
+          {:id :creatures-ancient-red-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+17 to hit, reach 10 ft., one target. _Hit: _17 (2d6 + 10) slashing damage."
+           :damage :slashing
+           :dice "2d6+10"
+           :to-hit 17})
+        (provide-attr
+          [:attacks :creatures-ancient-red-dragon/tail]
+          {:id :creatures-ancient-red-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+17 to hit, reach 20 ft., one target. _Hit: _19 (2d8 + 10) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+10"
+           :to-hit 17})
+        (provide-feature
+          {:id :creatures-ancient-red-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-red-dragon/fire-breath
+           :name "Fire Breath (Recharge 5–6)"
+           :desc "The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 91 (26d6) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-red-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-red-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-red-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-red-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-red-dragon
+   :name "Adult Red Dragon"
+   :ac 19
+   :challenge 17
+   :hit-points "19d12 + 133"
+   :abilities {:str 27 :dex 10 :con 25 :int 16 :wis 13 :cha 21}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 23"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., climb 40 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-red-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-red-dragon/multiattack]
+          {:id :creatures-adult-red-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-adult-red-dragon/bite]
+          {:id :creatures-adult-red-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 10 ft., one target. _Hit: _19 (2d10 + 8) piercing damage plus 7 (2d6) fire damage."
+           :damage :piercing
+           :dice "2d10+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-adult-red-dragon/claw]
+          {:id :creatures-adult-red-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 5 ft., one target. _Hit: _15 (2d6 + 8) slashing damage."
+           :damage :slashing
+           :dice "2d6+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-adult-red-dragon/tail]
+          {:id :creatures-adult-red-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 15 ft., one target. _Hit: _17 (2d8 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+8"
+           :to-hit 14})
+        (provide-feature
+          {:id :creatures-adult-red-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-red-dragon/fire-breath
+           :name "Fire Breath (Recharge 5–6)"
+           :desc "The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 63 (18d6) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-red-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-red-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-red-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-red-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-red-dragon
+   :name "Young Red Dragon"
+   :ac 18
+   :challenge 10
+   :hit-points "17d10 + 85"
+   :abilities {:str 23 :dex 10 :con 21 :int 14 :wis 11 :cha 19}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 18"
+   :size :large
+   :type :dragon
+   :speed "40 ft., climb 40 ft., fly 80 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-young-red-dragon/multiattack]
+          {:id :creatures-young-red-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-red-dragon/bite]
+          {:id :creatures-young-red-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _17 (2d10 + 6) piercing damage plus 3 (1d6) fire damage."
+           :damage :piercing
+           :dice "2d10+6"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-young-red-dragon/claw]
+          {:id :creatures-young-red-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one target. _Hit: _13 (2d6 + 6) slashing damage."
+           :damage :slashing
+           :dice "2d6+6"
+           :to-hit 10})
+        (provide-feature
+          {:id :creatures-young-red-dragon/fire-breath
+           :name "Fire Breath (Recharge 5–6)"
+           :desc "The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/red-dragon-wyrmling
+   :name "Red Dragon Wyrmling"
+   :ac 17
+   :challenge 4
+   :hit-points "10d8 + 30"
+   :abilities {:str 19 :dex 10 :con 17 :int 12 :wis 11 :cha 15}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., climb 30 ft., fly 60 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-red-dragon-wyrmling/bite]
+          {:id :creatures-red-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _9 (1d10 + 4) piercing damage plus 3 (1d6) fire damage."
+           :damage :piercing
+           :dice "1d10+4"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-red-dragon-wyrmling/fire-breath
+           :name "Fire Breath (Recharge 5–6)"
+           :desc "The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC 13 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/ancient-white-dragon
+   :name "Ancient White Dragon"
+   :ac 20
+   :challenge 20
+   :hit-points "18d20 + 144"
+   :abilities {:str 26 :dex 10 :con 26 :int 10 :wis 13 :cha 14}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 23"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., burrow 40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-white-dragon/ice-walk
+           :name "Ice Walk"
+           :desc "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn’t cost it extra moment."})
+        (provide-feature
+          {:id :creatures-ancient-white-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-white-dragon/multiattack]
+          {:id :creatures-ancient-white-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-white-dragon/bite]
+          {:id :creatures-ancient-white-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 15 ft., one target. _Hit: _19 (2d10 + 8) piercing damage plus 9 (2d8) cold damage."
+           :damage :piercing
+           :dice "2d10+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-ancient-white-dragon/claw]
+          {:id :creatures-ancient-white-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 10 ft., one target. _Hit: _15 (2d6 + 8) slashing damage."
+           :damage :slashing
+           :dice "2d6+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-ancient-white-dragon/tail]
+          {:id :creatures-ancient-white-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 20 ft., one target. _Hit: _17 (2d8 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+8"
+           :to-hit 14})
+        (provide-feature
+          {:id :creatures-ancient-white-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-white-dragon/cold-breath
+           :name "Cold Breath (Recharge 5–6)"
+           :desc "The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 72 (16d8) cold damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-white-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-white-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-white-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-white-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-white-dragon
+   :name "Adult White Dragon"
+   :ac 18
+   :challenge 13
+   :hit-points "16d12 + 96"
+   :abilities {:str 22 :dex 10 :con 22 :int 8 :wis 12 :cha 12}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 21"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., burrow 30 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-white-dragon/ice-walk
+           :name "Ice Walk"
+           :desc "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn’t cost it extra moment."})
+        (provide-feature
+          {:id :creatures-adult-white-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-white-dragon/multiattack]
+          {:id :creatures-adult-white-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-adult-white-dragon/bite]
+          {:id :creatures-adult-white-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 10 ft., one target. _Hit: _17 (2d10 + 6) piercing damage plus 4 (1d8) cold damage."
+           :damage :piercing
+           :dice "2d10+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-white-dragon/claw]
+          {:id :creatures-adult-white-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 5 ft., one target. _Hit: _13 (2d6 + 6) slashing damage."
+           :damage :slashing
+           :dice "2d6+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-white-dragon/tail]
+          {:id :creatures-adult-white-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 15 ft., one target. _Hit: _15 (2d8 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+6"
+           :to-hit 11})
+        (provide-feature
+          {:id :creatures-adult-white-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-white-dragon/cold-breath
+           :name "Cold Breath (Recharge 5–6)"
+           :desc "The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-white-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-white-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-white-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-white-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-white-dragon
+   :name "Young White Dragon"
+   :ac 17
+   :challenge 6
+   :hit-points "14d10 + 56"
+   :abilities {:str 18 :dex 10 :con 18 :int 6 :wis 11 :cha 12}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 16"
+   :size :large
+   :type :dragon
+   :speed "40 ft., burrow 20 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-young-white-dragon/ice-walk
+           :name "Ice Walk"
+           :desc "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn’t cost it extra moment."})
+        (provide-attr
+          [:attacks :creatures-young-white-dragon/multiattack]
+          {:id :creatures-young-white-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-white-dragon/bite]
+          {:id :creatures-young-white-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one target. _Hit: _15 (2d10 + 4) piercing damage plus 4 (1d8) cold damage."
+           :damage :piercing
+           :dice "2d10+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-young-white-dragon/claw]
+          {:id :creatures-young-white-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-young-white-dragon/cold-breath
+           :name "Cold Breath (Recharge 5–6)"
+           :desc "The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 15 Constitution saving throw, taking 45 (10d8) cold damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/white-dragon-wyrmling
+   :name "White Dragon Wyrmling"
+   :ac 16
+   :challenge 2
+   :hit-points "5d8 + 10"
+   :abilities {:str 14 :dex 10 :con 14 :int 5 :wis 10 :cha 11}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., burrow 15 ft., fly 60 ft., swim 30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-white-dragon-wyrmling/bite]
+          {:id :creatures-white-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (1d10 + 2) piercing damage plus 2 (1d4) cold damage."
+           :damage :piercing
+           :dice "1d10+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-white-dragon-wyrmling/cold-breath
+           :name "Cold Breath (Recharge 5–6)"
+           :desc "The dragon exhales an icy blast of hail in a 15-foot cone. Each creature in that area must make a DC 12 Constitution saving throw, taking 22 (5d8) cold damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/ancient-brass-dragon
+   :name "Ancient Brass Dragon"
+   :ac 20
+   :challenge 20
+   :hit-points "17d20 + 119"
+   :abilities {:str 27 :dex 10 :con 25 :int 16 :wis 15 :cha 19}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 24"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., burrow 40 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-brass-dragon/multiattack]
+          {:id :creatures-ancient-brass-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-brass-dragon/bite]
+          {:id :creatures-ancient-brass-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 15 ft., one target. _Hit: _19 (2d10 + 8) piercing damage."
+           :damage :piercing
+           :dice "2d10+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-ancient-brass-dragon/claw]
+          {:id :creatures-ancient-brass-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 10 ft., one target. _Hit: _15 (2d6 + 8) slashing damage."
+           :damage :slashing
+           :dice "2d6+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-ancient-brass-dragon/tail]
+          {:id :creatures-ancient-brass-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 20 ft., one target. _Hit: _17 (2d8 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+8"
+           :to-hit 14})
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons:"})
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/fire-breath
+           :name "Fire Breath"
+           :desc "The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 21 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/sleep-breath
+           :name "Sleep Breath"
+           :desc "The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a DC 21 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."})
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/change-shape
+           :name "Change Shape"
+           :desc "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon’s choice)."})
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-brass-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-brass-dragon
+   :name "Adult Brass Dragon"
+   :ac 18
+   :challenge 13
+   :hit-points "15d12 + 75"
+   :abilities {:str 23 :dex 10 :con 21 :int 14 :wis 13 :cha 17}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 21"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., burrow 30 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-brass-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-brass-dragon/multiattack]
+          {:id :creatures-adult-brass-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-adult-brass-dragon/bite]
+          {:id :creatures-adult-brass-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 10 ft., one target. _Hit: _17 (2d10 + 6) piercing damage."
+           :damage :piercing
+           :dice "2d10+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-brass-dragon/claw]
+          {:id :creatures-adult-brass-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 5 ft., one target. _Hit: _13 (2d6 + 6) slashing damage."
+           :damage :slashing
+           :dice "2d6+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-brass-dragon/tail]
+          {:id :creatures-adult-brass-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 15 ft., one target. _Hit: _15 (2d8 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+6"
+           :to-hit 11})
+        (provide-feature
+          {:id :creatures-adult-brass-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-brass-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-adult-brass-dragon/fire-breath
+           :name "Fire Breath"
+           :desc "The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 45 (13d6) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-brass-dragon/sleep-breath
+           :name "Sleep Breath"
+           :desc "The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."})
+        (provide-feature
+          {:id :creatures-adult-brass-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-brass-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-brass-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-brass-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-brass-dragon
+   :name "Young Brass Dragon"
+   :ac 17
+   :challenge 6
+   :hit-points "13d10 + 39"
+   :abilities {:str 19 :dex 10 :con 17 :int 12 :wis 11 :cha 15}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 16"
+   :size :large
+   :type :dragon
+   :speed "40 ft., burrow 20 ft., fly 80 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-young-brass-dragon/multiattack]
+          {:id :creatures-young-brass-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-brass-dragon/bite]
+          {:id :creatures-young-brass-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one target. _Hit: _15 (2d10 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d10+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-young-brass-dragon/claw]
+          {:id :creatures-young-brass-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-young-brass-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-young-brass-dragon/fire-breath
+           :name "Fire Breath"
+           :desc "The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 42 (12d6) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-young-brass-dragon/sleep-breath
+           :name "Sleep Breath"
+           :desc "The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."}))}
+  {:id :creatures/brass-dragon-wyrmling
+   :name "Brass Dragon Wyrmling"
+   :ac 16
+   :challenge 1
+   :hit-points "3d8 + 3"
+   :abilities {:str 15 :dex 10 :con 13 :int 10 :wis 11 :cha 13}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., burrow 15 ft., fly 60 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-brass-dragon-wyrmling/bite]
+          {:id :creatures-brass-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (1d10 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d10+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-brass-dragon-wyrmling/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-brass-dragon-wyrmling/fire-breath
+           :name "Fire Breath"
+           :desc "The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 14 (4d6) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-brass-dragon-wyrmling/sleep-breath
+           :name "Sleep Breath"
+           :desc "The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."}))}
+  {:id :creatures/ancient-bronze-dragon
+   :name "Ancient Bronze Dragon"
+   :ac 22
+   :challenge 22
+   :hit-points "24d20 + 192"
+   :abilities {:str 29 :dex 10 :con 27 :int 18 :wis 17 :cha 21}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 27"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-bronze-dragon/multiattack]
+          {:id :creatures-ancient-bronze-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-bronze-dragon/bite]
+          {:id :creatures-ancient-bronze-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+16 to hit, reach 15 ft., one target. _Hit: _20 (2d10 + 9) piercing damage."
+           :damage :piercing
+           :dice "2d10+9"
+           :to-hit 16})
+        (provide-attr
+          [:attacks :creatures-ancient-bronze-dragon/claw]
+          {:id :creatures-ancient-bronze-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+16 to hit, reach 10 ft., one target. _Hit: _16 (2d6 + 9) slashing damage."
+           :damage :slashing
+           :dice "2d6+9"
+           :to-hit 16})
+        (provide-attr
+          [:attacks :creatures-ancient-bronze-dragon/tail]
+          {:id :creatures-ancient-bronze-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+16 to hit, reach 20 ft., one target. _Hit: _18 (2d8 + 9) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+9"
+           :to-hit 16})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 20 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/lightning-breath
+           :name "Lightning Breath"
+           :desc "The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/repulsion-breath
+           :name "Repulsion Breath"
+           :desc "The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 23 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon."})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/change-shape
+           :name "Change Shape"
+           :desc "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon’s choice)."})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-bronze-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 24 Dexterity saving throw or take 16 (2d6 + 9) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-bronze-dragon
+   :name "Adult Bronze Dragon"
+   :ac 19
+   :challenge 15
+   :hit-points "17d12 + 102"
+   :abilities {:str 25 :dex 10 :con 23 :int 16 :wis 15 :cha 19}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 22"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-bronze-dragon/multiattack]
+          {:id :creatures-adult-bronze-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-adult-bronze-dragon/bite]
+          {:id :creatures-adult-bronze-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+12 to hit, reach 10 ft., one target. _Hit: _18 (2d10 + 7) piercing damage."
+           :damage :piercing
+           :dice "2d10+7"
+           :to-hit 12})
+        (provide-attr
+          [:attacks :creatures-adult-bronze-dragon/claw]
+          {:id :creatures-adult-bronze-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+12 to hit, reach 5 ft., one target. _Hit: _14 (2d6 + 7) slashing damage."
+           :damage :slashing
+           :dice "2d6+7"
+           :to-hit 12})
+        (provide-attr
+          [:attacks :creatures-adult-bronze-dragon/tail]
+          {:id :creatures-adult-bronze-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+12 to hit, reach 15 ft., one target. _Hit: _16 (2d8 + 7) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+7"
+           :to-hit 12})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/lightning-breath
+           :name "Lightning Breath"
+           :desc "The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/repulsion-breath
+           :name "Repulsion Breath"
+           :desc "The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 19 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon."})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/change-shape
+           :name "Change Shape"
+           :desc "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon’s choice)."})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-bronze-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 20 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-bronze-dragon
+   :name "Young Bronze Dragon"
+   :ac 18
+   :challenge 8
+   :hit-points "15d10 + 60"
+   :abilities {:str 21 :dex 10 :con 19 :int 14 :wis 13 :cha 17}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 17"
+   :size :large
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-young-bronze-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-young-bronze-dragon/multiattack]
+          {:id :creatures-young-bronze-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-bronze-dragon/bite]
+          {:id :creatures-young-bronze-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 10 ft., one target. _Hit: _16 (2d10 + 5) piercing damage."
+           :damage :piercing
+           :dice "2d10+5"
+           :to-hit 8})
+        (provide-attr
+          [:attacks :creatures-young-bronze-dragon/claw]
+          {:id :creatures-young-bronze-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _12 (2d6 + 5) slashing damage."
+           :damage :slashing
+           :dice "2d6+5"
+           :to-hit 8})
+        (provide-feature
+          {:id :creatures-young-bronze-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-young-bronze-dragon/lightning-breath
+           :name "Lightning Breath"
+           :desc "The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 15 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-young-bronze-dragon/repulsion-breath
+           :name "Repulsion Breath"
+           :desc "The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 15 Strength saving throw. On a failed save, the creature is pushed 40 feet away from the dragon."}))}
+  {:id :creatures/bronze-dragon-wyrmling
+   :name "Bronze Dragon Wyrmling"
+   :ac 17
+   :challenge 2
+   :hit-points "5d8 + 10"
+   :abilities {:str 17 :dex 10 :con 15 :int 12 :wis 11 :cha 15}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., fly 60 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-bronze-dragon-wyrmling/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-bronze-dragon-wyrmling/bite]
+          {:id :creatures-bronze-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _8 (1d10 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d10+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-bronze-dragon-wyrmling/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-bronze-dragon-wyrmling/lightning-breath
+           :name "Lightning Breath"
+           :desc "The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 16 (3d10) lightning damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-bronze-dragon-wyrmling/repulsion-breath
+           :name "Repulsion Breath"
+           :desc "The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 12 Strength saving throw. On a failed save, the creature is pushed 30 feet away from the dragon."}))}
+  {:id :creatures/ancient-copper-dragon
+   :name "Ancient Copper Dragon"
+   :ac 21
+   :challenge 21
+   :hit-points "20d20 + 140"
+   :abilities {:str 27 :dex 12 :con 25 :int 20 :wis 17 :cha 19}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 27"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., climb 40 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-copper-dragon/multiattack]
+          {:id :creatures-ancient-copper-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-copper-dragon/bite]
+          {:id :creatures-ancient-copper-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 15 ft., one target. _Hit: _19 (2d10 + 8) piercing damage."
+           :damage :piercing
+           :dice "2d10+8"
+           :to-hit 15})
+        (provide-attr
+          [:attacks :creatures-ancient-copper-dragon/claw]
+          {:id :creatures-ancient-copper-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 10 ft., one target. _Hit: _15 (2d6 + 8) slashing damage."
+           :damage :slashing
+           :dice "2d6+8"
+           :to-hit 15})
+        (provide-attr
+          [:attacks :creatures-ancient-copper-dragon/tail]
+          {:id :creatures-ancient-copper-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+15 to hit, reach 20 ft., one target. _Hit: _17 (2d8 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+8"
+           :to-hit 15})
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/acid-breath
+           :name "Acid Breath"
+           :desc "The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 22 Dexterity saving throw, taking 63 (14d8) acid damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/slowing-breath
+           :name "Slowing Breath"
+           :desc "The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 22 Constitution saving throw. On a failed save, the creature can’t use reactions, its speed is halved, and it can’t make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."})
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/change-shape
+           :name "Change Shape"
+           :desc "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon’s choice)."})
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-copper-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-copper-dragon
+   :name "Adult Copper Dragon"
+   :ac 18
+   :challenge 14
+   :hit-points "16d12 + 80"
+   :abilities {:str 23 :dex 12 :con 21 :int 18 :wis 15 :cha 17}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 22"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., climb 40 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-copper-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-copper-dragon/multiattack]
+          {:id :creatures-adult-copper-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-adult-copper-dragon/bite]
+          {:id :creatures-adult-copper-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 10 ft., one target. _Hit: _17 (2d10 + 6) piercing damage."
+           :damage :piercing
+           :dice "2d10+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-copper-dragon/claw]
+          {:id :creatures-adult-copper-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 5 ft., one target. _Hit: _13 (2d6 + 6) slashing damage."
+           :damage :slashing
+           :dice "2d6+6"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-adult-copper-dragon/tail]
+          {:id :creatures-adult-copper-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 15 ft., one target. _Hit: _15 (2d8 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+6"
+           :to-hit 11})
+        (provide-feature
+          {:id :creatures-adult-copper-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-copper-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-adult-copper-dragon/acid-breath
+           :name "Acid Breath"
+           :desc "The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-copper-dragon/slowing-breath
+           :name "Slowing Breath"
+           :desc "The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw. On a failed save, the creature can’t use reactions, its speed is halved, and it can’t make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."})
+        (provide-feature
+          {:id :creatures-adult-copper-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-copper-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-copper-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-copper-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-copper-dragon
+   :name "Young Copper Dragon"
+   :ac 17
+   :challenge 7
+   :hit-points "14d10 + 42"
+   :abilities {:str 19 :dex 12 :con 17 :int 16 :wis 13 :cha 15}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 17"
+   :size :large
+   :type :dragon
+   :speed "40 ft., climb 40 ft., fly 80 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-young-copper-dragon/multiattack]
+          {:id :creatures-young-copper-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-copper-dragon/bite]
+          {:id :creatures-young-copper-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one target. _Hit: _15 (2d10 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d10+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-young-copper-dragon/claw]
+          {:id :creatures-young-copper-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-young-copper-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-young-copper-dragon/acid-breath
+           :name "Acid Breath"
+           :desc "The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 40 (9d8) acid damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-young-copper-dragon/slowing-breath
+           :name "Slowing Breath"
+           :desc "The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw. On a failed save, the creature can’t use reactions, its speed is halved, and it can’t make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."}))}
+  {:id :creatures/copper-dragon-wyrmling
+   :name "Copper Dragon Wyrmling"
+   :ac 16
+   :challenge 1
+   :hit-points "4d8 + 4"
+   :abilities {:str 15 :dex 12 :con 13 :int 14 :wis 11 :cha 13}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., climb 30 ft., fly 60 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-copper-dragon-wyrmling/bite]
+          {:id :creatures-copper-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (1d10 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d10+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-copper-dragon-wyrmling/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-copper-dragon-wyrmling/acid-breath
+           :name "Acid Breath"
+           :desc "The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 18 (4d8) acid damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-copper-dragon-wyrmling/slowing-breath
+           :name "Slowing Breath"
+           :desc "The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw. On a failed save, the creature can’t use reactions, its speed is halved, and it can’t make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."}))}
+  {:id :creatures/ancient-gold-dragon
+   :name "Ancient Gold Dragon"
+   :ac 22
+   :challenge 24
+   :hit-points "28d20 + 252"
+   :abilities {:str 30 :dex 14 :con 29 :int 18 :wis 17 :cha 28}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 27"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-gold-dragon/multiattack]
+          {:id :creatures-ancient-gold-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-gold-dragon/bite]
+          {:id :creatures-ancient-gold-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+17 to hit, reach 15 ft., one target. _Hit: _21 (2d10 + 10) piercing damage."
+           :damage :piercing
+           :dice "2d10+10"
+           :to-hit 17})
+        (provide-attr
+          [:attacks :creatures-ancient-gold-dragon/claw]
+          {:id :creatures-ancient-gold-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+17 to hit, reach 10 ft., one target. _Hit: _17 (2d6 + 10) slashing damage."
+           :damage :slashing
+           :dice "2d6+10"
+           :to-hit 17})
+        (provide-attr
+          [:attacks :creatures-ancient-gold-dragon/tail]
+          {:id :creatures-ancient-gold-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+17 to hit, reach 20 ft., one target. _Hit: _19 (2d8 + 10) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+10"
+           :to-hit 17})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 24 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/fire-breath
+           :name "Fire Breath"
+           :desc "The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 71 (13d10) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/weakening-breath
+           :name "Weakening Breath"
+           :desc "The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 24 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/change-shape
+           :name "Change Shape"
+           :desc "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon’s choice)."})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-gold-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-gold-dragon
+   :name "Adult Gold Dragon"
+   :ac 19
+   :challenge 17
+   :hit-points "19d12 + 133"
+   :abilities {:str 27 :dex 14 :con 25 :int 16 :wis 15 :cha 24}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 24"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-gold-dragon/multiattack]
+          {:id :creatures-adult-gold-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-adult-gold-dragon/bite]
+          {:id :creatures-adult-gold-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 10 ft., one target. _Hit: _19 (2d10 + 8) piercing damage."
+           :damage :piercing
+           :dice "2d10+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-adult-gold-dragon/claw]
+          {:id :creatures-adult-gold-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 5 ft., one target. _Hit: _15 (2d6 + 8) slashing damage."
+           :damage :slashing
+           :dice "2d6+8"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-adult-gold-dragon/tail]
+          {:id :creatures-adult-gold-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 15 ft., one target. _Hit: _17 (2d8 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+8"
+           :to-hit 14})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/fire-breath
+           :name "Fire Breath"
+           :desc "The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 66 (12d10) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/weakening-breath
+           :name "Weakening Breath"
+           :desc "The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 21 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/change-shape
+           :name "Change Shape"
+           :desc "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon’s choice)."})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-gold-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-gold-dragon
+   :name "Young Gold Dragon"
+   :ac 18
+   :challenge 10
+   :hit-points "17d10 + 85"
+   :abilities {:str 23 :dex 14 :con 21 :int 16 :wis 13 :cha 20}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 19"
+   :size :large
+   :type :dragon
+   :speed "40 ft., fly 80 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-young-gold-dragon/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-young-gold-dragon/multiattack]
+          {:id :creatures-young-gold-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-gold-dragon/bite]
+          {:id :creatures-young-gold-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _17 (2d10 + 6) piercing damage."
+           :damage :piercing
+           :dice "2d10+6"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-young-gold-dragon/claw]
+          {:id :creatures-young-gold-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one target. _Hit: _13 (2d6 + 6) slashing damage."
+           :damage :slashing
+           :dice "2d6+6"
+           :to-hit 10})
+        (provide-feature
+          {:id :creatures-young-gold-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-young-gold-dragon/fire-breath
+           :name "Fire Breath"
+           :desc "The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 55 (10d10) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-young-gold-dragon/weakening-breath
+           :name "Weakening Breath"
+           :desc "The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."}))}
+  {:id :creatures/gold-dragon-wyrmling
+   :name "Gold Dragon Wyrmling"
+   :ac 17
+   :challenge 3
+   :hit-points "8d8 + 24"
+   :abilities {:str 19 :dex 14 :con 17 :int 14 :wis 11 :cha 16}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., fly 60 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gold-dragon-wyrmling/amphibious
+           :name "Amphibious"
+           :desc "The dragon can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-gold-dragon-wyrmling/bite]
+          {:id :creatures-gold-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _9 (1d10 + 4) piercing damage."
+           :damage :piercing
+           :dice "1d10+4"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-gold-dragon-wyrmling/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-gold-dragon-wyrmling/fire-breath
+           :name "Fire Breath"
+           :desc "The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC 13 Dexterity saving throw, taking 22 (4d10) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-gold-dragon-wyrmling/weakening-breath
+           :name "Weakening Breath"
+           :desc "The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."}))}
+  {:id :creatures/ancient-silver-dragon
+   :name "Ancient Silver Dragon"
+   :ac 22
+   :challenge 23
+   :hit-points "25d20 + 225"
+   :abilities {:str 30 :dex 10 :con 29 :int 18 :wis 15 :cha 23}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 26"
+   :size :gargantuan
+   :type :dragon
+   :speed "40 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-ancient-silver-dragon/multiattack]
+          {:id :creatures-ancient-silver-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-ancient-silver-dragon/bite]
+          {:id :creatures-ancient-silver-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+17 to hit, reach 15 ft., one target. _Hit: _21 (2d10 + 10) piercing damage."
+           :damage :piercing
+           :dice "2d10+10"
+           :to-hit 17})
+        (provide-attr
+          [:attacks :creatures-ancient-silver-dragon/claw]
+          {:id :creatures-ancient-silver-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+17 to hit, reach 10 ft., one target. _Hit: _17 (2d6 + 10) slashing damage."
+           :damage :slashing
+           :dice "2d6+10"
+           :to-hit 17})
+        (provide-attr
+          [:attacks :creatures-ancient-silver-dragon/tail]
+          {:id :creatures-ancient-silver-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+17 to hit, reach 20 ft., one target. _Hit: _19 (2d8 + 10) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+10"
+           :to-hit 17})
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/cold-breath
+           :name "Cold Breath"
+           :desc "The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 24 Constitution saving throw, taking 67 (15d8) cold damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/paralyzing-breath
+           :name "Paralyzing Breath"
+           :desc "The dragon exhales paralyzing gas in a 90-foot cone. Each creature in that area must succeed on a DC 24 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."})
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/change-shape
+           :name "Change Shape"
+           :desc "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon’s choice)."})
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-ancient-silver-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 15 feet of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/adult-silver-dragon
+   :name "Adult Silver Dragon"
+   :ac 19
+   :challenge 16
+   :hit-points "18d12 + 126"
+   :abilities {:str 27 :dex 10 :con 25 :int 16 :wis 13 :cha 21}
+   :senses "blindsight 60 ft., darkvision 120 ft., passive Perception 21"
+   :size :huge
+   :type :dragon
+   :speed "40 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the dragon fails a saving throw, it can choose to succeed instead."})
+        (provide-attr
+          [:attacks :creatures-adult-silver-dragon/multiattack]
+          {:id :creatures-adult-silver-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-adult-silver-dragon/bite]
+          {:id :creatures-adult-silver-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 10 ft., one target. _Hit: _19 (2d10 + 8) piercing damage."
+           :damage :piercing
+           :dice "2d10+8"
+           :to-hit 13})
+        (provide-attr
+          [:attacks :creatures-adult-silver-dragon/claw]
+          {:id :creatures-adult-silver-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 5 ft., one target. _Hit: _15 (2d6 + 8) slashing damage."
+           :damage :slashing
+           :dice "2d6+8"
+           :to-hit 13})
+        (provide-attr
+          [:attacks :creatures-adult-silver-dragon/tail]
+          {:id :creatures-adult-silver-dragon/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 15 ft., one target. _Hit: _17 (2d8 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+8"
+           :to-hit 13})
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the dragon’s choice that is within 120 feet of the dragon and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the dragon’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/cold-breath
+           :name "Cold Breath"
+           :desc "The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 20 Constitution saving throw, taking 58 (13d8) cold damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/paralyzing-breath
+           :name "Paralyzing Breath"
+           :desc "The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must succeed on a DC 20 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."})
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/change-shape
+           :name "Change Shape"
+           :desc "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon’s choice)."})
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/detect
+           :name "Detect"
+           :desc "The dragon makes a Wisdom (Perception) check."})
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/tail-attack
+           :name "Tail Attack"
+           :desc "The dragon makes a tail attack."})
+        (provide-feature
+          {:id :creatures-adult-silver-dragon/wing-attack
+           :name "Wing Attack (Costs 2 Actions)"
+           :desc "The dragon beats its wings. Each creature within 10 feet of the dragon must succeed on a DC 21 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."}))}
+  {:id :creatures/young-silver-dragon
+   :name "Young Silver Dragon"
+   :ac 18
+   :challenge 9
+   :hit-points "16d10 + 80"
+   :abilities {:str 23 :dex 10 :con 21 :int 14 :wis 11 :cha 19}
+   :senses "blindsight 30 ft., darkvision 120 ft., passive Perception 18"
+   :size :large
+   :type :dragon
+   :speed "40 ft., fly 80 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-young-silver-dragon/multiattack]
+          {:id :creatures-young-silver-dragon/multiattack
+           :name "Multiattack"
+           :desc "The dragon makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-young-silver-dragon/bite]
+          {:id :creatures-young-silver-dragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _17 (2d10 + 6) piercing damage."
+           :damage :piercing
+           :dice "2d10+6"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-young-silver-dragon/claw]
+          {:id :creatures-young-silver-dragon/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one target. _Hit: _13 (2d6 + 6) slashing damage."
+           :damage :slashing
+           :dice "2d6+6"
+           :to-hit 10})
+        (provide-feature
+          {:id :creatures-young-silver-dragon/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-young-silver-dragon/cold-breath
+           :name "Cold Breath"
+           :desc "The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 17 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-young-silver-dragon/paralyzing-breath
+           :name "Paralyzing Breath"
+           :desc "The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."}))}
+  {:id :creatures/silver-dragon-wyrmling
+   :name "Silver Dragon Wyrmling"
+   :ac 17
+   :challenge 2
+   :hit-points "6d8 + 18"
+   :abilities {:str 19 :dex 10 :con 17 :int 12 :wis 11 :cha 15}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :dragon
+   :speed "30 ft., fly 60 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-silver-dragon-wyrmling/bite]
+          {:id :creatures-silver-dragon-wyrmling/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _9 (1d10 + 4) piercing damage."
+           :damage :piercing
+           :dice "1d10+4"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-silver-dragon-wyrmling/breath-weapons
+           :name "Breath Weapons (Recharge 5–6)"
+           :desc "The dragon uses one of the following breath weapons."})
+        (provide-feature
+          {:id :creatures-silver-dragon-wyrmling/cold-breath
+           :name "Cold Breath"
+           :desc "The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a DC 13 Constitution saving throw, taking 18 (4d8) cold damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-silver-dragon-wyrmling/paralyzing-breath
+           :name "Paralyzing Breath"
+           :desc "The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."}))}
+  {:id :creatures/dragon-turtle
+   :name "Dragon Turtle"
+   :ac 20
+   :challenge 17
+   :hit-points "22d20 + 110"
+   :abilities {:str 25 :dex 10 :con 20 :int 10 :wis 12 :cha 12}
+   :senses "darkvision 120 ft., passive Perception 11"
+   :size :gargantuan
+   :type :dragon
+   :speed "20 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-dragon-turtle/amphibious
+           :name "Amphibious"
+           :desc "The dragon turtle can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-dragon-turtle/multiattack]
+          {:id :creatures-dragon-turtle/multiattack
+           :name "Multiattack"
+           :desc "The dragon turtle makes three attacks: one with its bite and two with its claws. It can make one tail attack in place of its two claw attacks."})
+        (provide-attr
+          [:attacks :creatures-dragon-turtle/bite]
+          {:id :creatures-dragon-turtle/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 15 ft., one target. _Hit: _26 (3d12 + 7) piercing damage."
+           :damage :piercing
+           :dice "3d12+7"
+           :to-hit 13})
+        (provide-attr
+          [:attacks :creatures-dragon-turtle/claw]
+          {:id :creatures-dragon-turtle/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 10 ft., one target. _Hit: _16 (2d8 + 7) slashing damage."
+           :damage :slashing
+           :dice "2d8+7"
+           :to-hit 13})
+        (provide-attr
+          [:attacks :creatures-dragon-turtle/tail]
+          {:id :creatures-dragon-turtle/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 15 ft., one target. _Hit: _26 (3d12 + 7) bludgeoning damage. If the target is a creature, it must succeed on a DC 20 Strength saving throw or be pushed up to 10 feet away from the dragon turtle and knocked prone."
+           :damage :bludgeoning
+           :dice "3d12+7"
+           :to-hit 13})
+        (provide-feature
+          {:id :creatures-dragon-turtle/steam-breath
+           :name "Steam Breath (Recharge 5–6)"
+           :desc "The dragon turtle exhales scalding steam in a 60-foot cone. Each creature in that area must make a DC 18 Constitution saving throw, taking 52 (15d6) fire damage on a failed save, or half as much damage on a successful one. Being underwater doesn’t grant resistance against this damage."}))}
+  {:id :creatures/drider
+   :name "Drider"
+   :ac 19
+   :challenge 6
+   :hit-points "13d10 + 52"
+   :abilities {:str 16 :dex 16 :con 18 :int 13 :wis 14 :cha 12}
+   :senses "darkvision 120 ft., passive Perception 15"
+   :size :large
+   :type :monstrosity
+   :speed "30 ft., climb 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-drider/fey-ancestry
+           :name "Fey Ancestry"
+           :desc "The drider has advantage on saving throws against being charmed, and magic can’t put the drider to sleep."})
+        (provide-feature
+          {:id :creatures-drider/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The drider’s innate spellcasting ability is Wisdom (spell save DC 13). The drider can innately cast the following spells, requiring no material components:"})
+        (provide-feature
+          {:id :creatures-drider/spider-climb
+           :name "Spider Climb"
+           :desc "The drider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."})
+        (provide-feature
+          {:id :creatures-drider/sunlight-sensitivity
+           :name "Sunlight Sensitivity"
+           :desc "While in sunlight, the drider has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."})
+        (provide-feature
+          {:id :creatures-drider/web-walker
+           :name "Web Walker"
+           :desc "The drider ignores movement restrictions caused by webbing."})
+        (provide-attr
+          [:attacks :creatures-drider/multiattack]
+          {:id :creatures-drider/multiattack
+           :name "Multiattack"
+           :desc "The drider makes three attacks, either with its longsword or its longbow. It can replace one of those attacks with a bite attack."})
+        (provide-attr
+          [:attacks :creatures-drider/bite]
+          {:id :creatures-drider/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one creature. _Hit: _2 (1d4) piercing damage plus 9 (2d8) poison damage."
+           :damage :piercing
+           :dice "1d4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-drider/longsword]
+          {:id :creatures-drider/longsword
+           :name "Longsword"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands."
+           :damage :slashing
+           :dice "1d8+3"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-drider/longbow]
+          {:id :creatures-drider/longbow
+           :name "Longbow"
+           :desc "_Ranged Weapon Attack: _+6 to hit, range 150/600 ft., one target. _Hit: _7 (1d8 + 3) piercing damage plus 4 (1d8) poison damage."
+           :damage :piercing
+           :dice "1d8+3"
+           :to-hit 6}))}
+  {:id :creatures/duergar
+   :name "Duergar"
+   :ac 16
+   :challenge 1
+   :hit-points "4d8 + 8"
+   :abilities {:str 14 :dex 11 :con 14 :int 11 :wis 10 :cha 9}
+   :senses "darkvision 120 ft., passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "25 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-duergar/duergar-resilience
+           :name "Duergar Resilience"
+           :desc "The duergar has advantage on saving throws against poison, spells, and illusions, as well as to resist being charmed or paralyzed."})
+        (provide-feature
+          {:id :creatures-duergar/sunlight-sensitivity
+           :name "Sunlight Sensitivity"
+           :desc "While in sunlight, the duergar has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."})
+        (provide-feature
+          {:id :creatures-duergar/enlarge
+           :name "Enlarge (Recharges after a Short or Long Rest)"
+           :desc "For 1 minute, the duergar magically increases in size, along with anything it is wearing or carrying. While enlarged, the duergar is Large, doubles its damage dice on Strength-based weapon attacks (included in the attacks), and makes Strength checks and Strength saving throws with advantage. If the duergar lacks the room to become Large, it attains the maximum size possible in the space available."})
+        (provide-attr
+          [:attacks :creatures-duergar/war-pick]
+          {:id :creatures-duergar/war-pick
+           :name "War Pick"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _6 (1d8 + 2) piercing damage, or 11 (2d8 + 2) piercing damage while enlarged."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-duergar/javelin]
+          {:id :creatures-duergar/javelin
+           :name "Javelin"
+           :desc "_Melee or Ranged Weapon Attack: _+4 to hit, reach 5 ft. or range 30/120 ft., one target. _Hit: _5 (1d6 + 2) piercing damage, or 9 (2d6 + 2) piercing damage while enlarged."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-duergar/invisibility
+           :name "Invisibility (Recharges after a Short or Long Rest)"
+           :desc "The duergar magically turns invisible until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell). Any equipment the duergar wears or carries is invisible with it."}))}
+  {:id :creatures/air-elemental
+   :name "Air Elemental"
+   :ac 15
+   :challenge 5
+   :hit-points "12d10 + 24"
+   :abilities {:str 14 :dex 20 :con 14 :int 6 :wis 10 :cha 6}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :large
+   :type :elemental
+   :speed "0 ft., fly 90 ft. (hover)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-air-elemental/air-form
+           :name "Air Form"
+           :desc "The elemental can enter a hostile creature’s space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."})
+        (provide-attr
+          [:attacks :creatures-air-elemental/multiattack]
+          {:id :creatures-air-elemental/multiattack
+           :name "Multiattack"
+           :desc "The elemental makes two slam attacks."})
+        (provide-attr
+          [:attacks :creatures-air-elemental/slam]
+          {:id :creatures-air-elemental/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _14 (2d8 + 5) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+5"
+           :to-hit 8})
+        (provide-feature
+          {:id :creatures-air-elemental/whirlwind
+           :name "Whirlwind (Recharge 4–6)"
+           :desc "Each creature in the elemental’s space must make a DC 13 Strength saving throw. On a failure, a target takes 15 (3d8 + 2) bludgeoning damage and is flung up 20 feet away from the elemental in a random direction and knocked prone. If a thrown target strikes an object, such as a wall or floor, the target takes 3 (1d6) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a DC 13 Dexterity saving throw or take the same damage and be knocked prone."}))}
+  {:id :creatures/earth-elemental
+   :name "Earth Elemental"
+   :ac 17
+   :challenge 5
+   :hit-points "12d10 + 60"
+   :abilities {:str 20 :dex 8 :con 20 :int 5 :wis 10 :cha 5}
+   :senses "darkvision 60 ft., tremorsense 60 ft., passive Perception 10"
+   :size :large
+   :type :elemental
+   :speed "30 ft., burrow 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-earth-elemental/earth-glide
+           :name "Earth Glide"
+           :desc "The elemental can burrow through nonmagical, unworked earth and stone. While doing so, the elemental doesn’t disturb the material it moves through."})
+        (provide-feature
+          {:id :creatures-earth-elemental/siege-monster
+           :name "Siege Monster"
+           :desc "The elemental deals double damage to objects and structures."})
+        (provide-attr
+          [:attacks :creatures-earth-elemental/multiattack]
+          {:id :creatures-earth-elemental/multiattack
+           :name "Multiattack"
+           :desc "The elemental makes two slam attacks."})
+        (provide-attr
+          [:attacks :creatures-earth-elemental/slam]
+          {:id :creatures-earth-elemental/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 10 ft., one target. _Hit: _14 (2d8 + 5) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+5"
+           :to-hit 8}))}
+  {:id :creatures/fire-elemental
+   :name "Fire Elemental"
+   :ac 13
+   :challenge 5
+   :hit-points "12d10 + 36"
+   :abilities {:str 10 :dex 17 :con 16 :int 6 :wis 10 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :large
+   :type :elemental
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-fire-elemental/fire-form
+           :name "Fire Form"
+           :desc "The elemental can move through a space as narrow as 1 inch wide without squeezing. A creature that touches the elemental or hits it with a melee attack while within 5 feet of it takes 5 (1d10) fire damage. In addition, the elemental can enter a hostile creature’s space and stop there. The first time it enters a creature’s space on a turn, that creature takes 5 (1d10) fire damage and catches fire; until someone takes an action to douse the fire, the creature takes 5 (1d10) fire damage at the start of each of its turns."})
+        (provide-feature
+          {:id :creatures-fire-elemental/illumination
+           :name "Illumination"
+           :desc "The elemental sheds bright light in a 30-foot radius and dim light in an additional 30 feet."})
+        (provide-feature
+          {:id :creatures-fire-elemental/water-susceptibility
+           :name "Water Susceptibility"
+           :desc "For every 5 feet the elemental moves in water, or for every gallon of water splashed on it, it takes 1 cold damage."})
+        (provide-attr
+          [:attacks :creatures-fire-elemental/multiattack]
+          {:id :creatures-fire-elemental/multiattack
+           :name "Multiattack"
+           :desc "The elemental makes two touch attacks."})
+        (provide-attr
+          [:attacks :creatures-fire-elemental/touch]
+          {:id :creatures-fire-elemental/touch
+           :name "Touch"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) fire damage. If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes 5 (1d10) fire damage at the start of each of its turns."
+           :damage :fire
+           :dice "2d6+3"
+           :to-hit 6}))}
+  {:id :creatures/water-elemental
+   :name "Water Elemental"
+   :ac 14
+   :challenge 5
+   :hit-points "12d10 + 48"
+   :abilities {:str 18 :dex 14 :con 18 :int 5 :wis 10 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :large
+   :type :elemental
+   :speed "30 ft., swim 90 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-water-elemental/water-form
+           :name "Water Form"
+           :desc "The elemental can enter a hostile creature’s space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."})
+        (provide-feature
+          {:id :creatures-water-elemental/freeze
+           :name "Freeze"
+           :desc "If the elemental takes cold damage, it partially freezes; its speed is reduced by 20 feet until the end of its next turn."})
+        (provide-attr
+          [:attacks :creatures-water-elemental/multiattack]
+          {:id :creatures-water-elemental/multiattack
+           :name "Multiattack"
+           :desc "The elemental makes two slam attacks."})
+        (provide-attr
+          [:attacks :creatures-water-elemental/slam]
+          {:id :creatures-water-elemental/slam
+           :name "Slam"
+           :desc "Melee _Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-water-elemental/whelm
+           :name "Whelm (Recharge 4–6)"
+           :desc "Each creature in the elemental’s space must make a DC 15 Strength saving throw. On a failure, a target takes 13 (2d8 + 4) bludgeoning damage. If it is Large or smaller, it is also grappled (escape DC 14). Until this grapple ends, the target is restrained and unable to breathe unless it can breathe water. If the saving throw is successful, the target is pushed out of the elemental’s space."}))}
+  {:id :creatures/elf-drow
+   :name "Elf, Drow"
+   :ac 15
+   :challenge 0.25
+   :hit-points "3d8"
+   :abilities {:str 10 :dex 14 :con 10 :int 11 :wis 11 :cha 12}
+   :senses "darkvision 120 ft., passive Perception 12"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-elf-drow/fey-ancestry
+           :name "Fey Ancestry"
+           :desc "The drow has advantage on saving throws against being charmed, and magic can’t put the drow to sleep."})
+        (provide-feature
+          {:id :creatures-elf-drow/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The drow’s spellcasting ability is Charisma (spell save DC 11). It can innately cast the following spells, requiring no material components:"})
+        (provide-feature
+          {:id :creatures-elf-drow/sunlight-sensitivity
+           :name "Sunlight Sensitivity"
+           :desc "While in sunlight, the drow has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-elf-drow/shortsword]
+          {:id :creatures-elf-drow/shortsword
+           :name "Shortsword"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-elf-drow/hand-crossbow]
+          {:id :creatures-elf-drow/hand-crossbow
+           :name "Hand Crossbow"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 30/120 ft., one target. _Hit: _5 (1d6 + 2) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the target is also unconscious while poisoned in this way. The target wakes up if it takes damage or if another creature takes an action to shake it awake."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/ettercap
+   :name "Ettercap"
+   :ac 13
+   :challenge 2
+   :hit-points "8d8 + 8"
+   :abilities {:str 14 :dex 15 :con 13 :int 7 :wis 12 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 13"
+   :size :medium
+   :type :monstrosity
+   :speed "30 ft., climb 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ettercap/spider-climb
+           :name "Spider Climb"
+           :desc "The ettercap can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."})
+        (provide-feature
+          {:id :creatures-ettercap/web-sense
+           :name "Web Sense"
+           :desc "While in contact with a web, the ettercap knows the exact location of any other creature in contact with the same web."})
+        (provide-feature
+          {:id :creatures-ettercap/web-walker
+           :name "Web Walker"
+           :desc "The ettercap ignores movement restrictions caused by webbing."})
+        (provide-attr
+          [:attacks :creatures-ettercap/multiattack]
+          {:id :creatures-ettercap/multiattack
+           :name "Multiattack"
+           :desc "The ettercap makes two attacks: one with its bite and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-ettercap/bite]
+          {:id :creatures-ettercap/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _6 (1d8 + 2) piercing damage plus 4 (1d8) poison damage. The target must succeed on a DC 11 Constitution saving throw or be poisoned for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-ettercap/claws]
+          {:id :creatures-ettercap/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (2d4 + 2) slashing damage."
+           :damage :slashing
+           :dice "2d4+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-ettercap/web]
+          {:id :creatures-ettercap/web
+           :name "Web (Recharge 5–6)"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 30/60 ft., one Large or smaller creature. _Hit: _The creature is restrained by webbing. As an action, the restrained creature can make a DC 11 Strength check, escaping from the webbing on a success. The effect also ends if the webbing is destroyed. The webbing has AC 10, 5 hit points, vulnerability to fire damage, and immunity to bludgeoning, poison, and psychic damage."
+           :to-hit 4}))}
+  {:id :creatures/ettin
+   :name "Ettin"
+   :ac 12
+   :challenge 4
+   :hit-points "10d10 + 30"
+   :abilities {:str 21 :dex 8 :con 17 :int 6 :wis 10 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :large
+   :type :giant
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ettin/two-heads
+           :name "Two Heads"
+           :desc "The ettin has advantage on Wisdom (Perception) checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious."})
+        (provide-feature
+          {:id :creatures-ettin/wakeful
+           :name "Wakeful"
+           :desc "When one of the ettin’s heads is asleep, its other head is awake."})
+        (provide-attr
+          [:attacks :creatures-ettin/multiattack]
+          {:id :creatures-ettin/multiattack
+           :name "Multiattack"
+           :desc "The ettin makes two attacks: one with its battleaxe and one with its morningstar."})
+        (provide-attr
+          [:attacks :creatures-ettin/battleaxe]
+          {:id :creatures-ettin/battleaxe
+           :name "Battleaxe"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _14 (2d8 + 5) slashing damage."
+           :damage :slashing
+           :dice "2d8+5"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-ettin/morningstar]
+          {:id :creatures-ettin/morningstar
+           :name "Morningstar"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _14 (2d8 + 5) piercing damage."
+           :damage :piercing
+           :dice "2d8+5"
+           :to-hit 7}))}
+  {:id :creatures/shrieker
+   :name "Shrieker"
+   :ac 5
+   :challenge 0
+   :hit-points "3d8"
+   :abilities {:str 1 :dex 1 :con 10 :int 1 :wis 3 :cha 1}
+   :senses "blindsight 30 ft. (blind beyond this radius), passive Perception 6"
+   :size :medium
+   :type :plant
+   :speed "0 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-shrieker/false-appearance
+           :name "False Appearance"
+           :desc "While the shrieker remains motionless, it is indistinguishable from an ordinary fungus."})
+        (provide-feature
+          {:id :creatures-shrieker/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-shrieker/shriek
+           :name "Shriek"
+           :desc "When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. The shrieker continues to shriek until the disturbance moves out of range and for 1d4 of the shrieker’s turns afterward."}))}
+  {:id :creatures/violet-fungus
+   :name "Violet Fungus"
+   :ac 5
+   :challenge 0.25
+   :hit-points "4d8"
+   :abilities {:str 3 :dex 1 :con 10 :int 1 :wis 3 :cha 1}
+   :senses "blindsight 30 ft. (blind beyond this radius), passive Perception 6"
+   :size :medium
+   :type :plant
+   :speed "5 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-violet-fungus/false-appearance
+           :name "False Appearance"
+           :desc "While the violet fungus remains motionless, it is indistinguishable from an ordinary fungus."})
+        (provide-attr
+          [:attacks :creatures-violet-fungus/multiattack]
+          {:id :creatures-violet-fungus/multiattack
+           :name "Multiattack"
+           :desc "The fungus makes 1d4 Rotting Touch attacks."})
+        (provide-attr
+          [:attacks :creatures-violet-fungus/rotting-touch]
+          {:id :creatures-violet-fungus/rotting-touch
+           :name "Rotting Touch"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 10 ft., one creature. _Hit: _4 (1d8) necrotic damage."
+           :damage :necrotic
+           :dice "1d8"
+           :to-hit 2}))}
+  {:id :creatures/gargoyle
+   :name "Gargoyle"
+   :ac 15
+   :challenge 2
+   :hit-points "7d8 + 21"
+   :abilities {:str 15 :dex 11 :con 16 :int 6 :wis 11 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :elemental
+   :speed "30 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gargoyle/false-appearance
+           :name "False Appearance"
+           :desc "While the gargoyle remains motionless, it is indistinguishable from an inanimate statue."})
+        (provide-attr
+          [:attacks :creatures-gargoyle/multiattack]
+          {:id :creatures-gargoyle/multiattack
+           :name "Multiattack"
+           :desc "The gargoyle makes two attacks: one with its bite and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-gargoyle/bite]
+          {:id :creatures-gargoyle/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-gargoyle/claws]
+          {:id :creatures-gargoyle/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) slashing damage."
+           :damage :slashing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/djinni
+   :name "Djinni"
+   :ac 17
+   :challenge 11
+   :hit-points "14d10 + 84"
+   :abilities {:str 21 :dex 15 :con 22 :int 15 :wis 16 :cha 20}
+   :senses "darkvision 120 ft., passive Perception 13"
+   :size :large
+   :type :elemental
+   :speed "30 ft., fly 90 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-djinni/elemental-demise
+           :name "Elemental Demise"
+           :desc "If the djinni dies, its body disintegrates into a warm breeze, leaving behind only equipment the djinni was wearing or carrying."})
+        (provide-feature
+          {:id :creatures-djinni/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The djinni’s innate spellcasting ability is Charisma (spell save DC 17, +9 to hit with spell attacks). It can innately cast the following spells, requiring no material components:"})
+        (provide-attr
+          [:attacks :creatures-djinni/multiattack]
+          {:id :creatures-djinni/multiattack
+           :name "Multiattack"
+           :desc "The djinni makes three scimitar attacks."})
+        (provide-attr
+          [:attacks :creatures-djinni/scimitar]
+          {:id :creatures-djinni/scimitar
+           :name "Scimitar"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one target. _Hit: _12 (2d6 + 5) slashing damage plus 3 (1d6) lightning or thunder damage (djinni’s choice)."
+           :damage :slashing
+           :dice "2d6+5"
+           :to-hit 9})
+        (provide-feature
+          {:id :creatures-djinni/create-whirlwind
+           :name "Create Whirlwind"
+           :desc "A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the djinni can see within 120 feet of it. The whirlwind lasts as long as the djinni maintains concentration (as if concentrating on a spell). Any creature but the djinni that enters the whirlwind must succeed on a DC 18 Strength saving throw or be restrained by it. The djinni can move the whirlwind up to 60 feet as an action, and creatures restrained by the whirlwind move with it. The whirlwind ends if the djinni loses sight of it."}))}
+  {:id :creatures/efreeti
+   :name "Efreeti"
+   :ac 17
+   :challenge 11
+   :hit-points "16d10 + 112"
+   :abilities {:str 22 :dex 12 :con 24 :int 16 :wis 15 :cha 16}
+   :senses "darkvision 120 ft., passive Perception 12"
+   :size :large
+   :type :elemental
+   :speed "40 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-efreeti/elemental-demise
+           :name "Elemental Demise"
+           :desc "If the efreeti dies, its body disintegrates in a flash of fire and puff of smoke, leaving behind only equipment the efreeti was wearing or carrying."})
+        (provide-feature
+          {:id :creatures-efreeti/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The efreeti’s innate spellcasting ability is Charisma (spell save DC 15, +7 to hit with spell attacks). It can innately cast the following spells, requiring no material components:"})
+        (provide-attr
+          [:attacks :creatures-efreeti/multiattack]
+          {:id :creatures-efreeti/multiattack
+           :name "Multiattack"
+           :desc "The efreeti makes two scimitar attacks or uses its Hurl Flame twice."})
+        (provide-attr
+          [:attacks :creatures-efreeti/scimitar]
+          {:id :creatures-efreeti/scimitar
+           :name "Scimitar"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one target. _Hit: _13 (2d6 + 6) slashing damage plus 7 (2d6) fire damage."
+           :damage :slashing
+           :dice "2d6+6"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-efreeti/hurl-flame]
+          {:id :creatures-efreeti/hurl-flame
+           :name "Hurl Flame"
+           :desc "_Ranged Spell Attack: _+7 to hit, range 120 ft., one target. _Hit: _17 (5d6) fire damage."
+           :damage :fire
+           :dice "5d6"
+           :to-hit 7}))}
+  {:id :creatures/ghost
+   :name "Ghost"
+   :ac 11
+   :challenge 4
+   :hit-points "10d8"
+   :abilities {:str 7 :dex 13 :con 10 :int 10 :wis 12 :cha 17}
+   :senses "darkvision 60 ft., passive Perception 11"
+   :size :medium
+   :type :undead
+   :speed "0 ft., fly 40 ft. (hover)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ghost/ethereal-sight
+           :name "Ethereal Sight"
+           :desc "The ghost can see 60 feet into the Ethereal Plane when it is on the Material Plane, and vice versa."})
+        (provide-feature
+          {:id :creatures-ghost/incorporeal-movement
+           :name "Incorporeal Movement"
+           :desc "The ghost can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."})
+        (provide-attr
+          [:attacks :creatures-ghost/withering-touch]
+          {:id :creatures-ghost/withering-touch
+           :name "Withering Touch"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _17 (4d6 + 3) necrotic damage."
+           :damage :necrotic
+           :dice "4d6+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-ghost/etherealness
+           :name "Etherealness"
+           :desc "The ghost enters the Ethereal Plane from the Material Plane, or vice versa. It is visible on the Material Plane while it is in the Border Ethereal, and vice versa, yet it can’t affect or be affected by anything on the other plane."})
+        (provide-feature
+          {:id :creatures-ghost/horrifying-visage
+           :name "Horrifying Visage"
+           :desc "Each non-undead creature within 60 feet of the ghost that can see it must succeed on a DC 13 Wisdom saving throw or be frightened for 1 minute. If the save fails by 5 or more, the target also ages 1d4 × 10 years. A frightened target can repeat the saving throw at the end of each of its turns, ending the frightened condition on itself on a success. If a target’s saving throw is successful or the effect ends for it, the target is immune to this ghost’s Horrifying Visage for the next 24 hours. The aging effect can be reversed with a _greater restoration_"}))}
+  {:id :creatures/ghast
+   :name "Ghast"
+   :ac 13
+   :challenge 2
+   :hit-points "8d8"
+   :abilities {:str 16 :dex 17 :con 10 :int 11 :wis 10 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :undead
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ghast/stench
+           :name "Stench"
+           :desc "Any creature that starts its turn within 5 feet of the ghast must succeed on a DC 10 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the ghast’s Stench for 24 hours."})
+        (provide-feature
+          {:id :creatures-ghast/turning-defiance
+           :name "Turning Defiance"
+           :desc "The ghast and any ghouls within 30 feet of it have advantage on saving throws against effects that turn undead."})
+        (provide-attr
+          [:attacks :creatures-ghast/bite]
+          {:id :creatures-ghast/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one creature. _Hit: _12 (2d8 + 3) piercing damage."
+           :damage :piercing
+           :dice "2d8+3"
+           :to-hit 3})
+        (provide-attr
+          [:attacks :creatures-ghast/claws]
+          {:id :creatures-ghast/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) slashing damage. If the target is a creature other than an undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+           :damage :slashing
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/ghoul
+   :name "Ghoul"
+   :ac 12
+   :challenge 1
+   :hit-points "5d8"
+   :abilities {:str 13 :dex 15 :con 10 :int 7 :wis 10 :cha 6}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :undead
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-ghoul/bite]
+          {:id :creatures-ghoul/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one creature. _Hit: _9 (2d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "2d6+2"
+           :to-hit 2})
+        (provide-attr
+          [:attacks :creatures-ghoul/claws]
+          {:id :creatures-ghoul/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (2d4 + 2) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+           :damage :slashing
+           :dice "2d4+2"
+           :to-hit 4}))}
+  {:id :creatures/cloud-giant
+   :name "Cloud Giant"
+   :ac 14
+   :challenge 9
+   :hit-points "16d12 + 96"
+   :abilities {:str 27 :dex 10 :con 22 :int 12 :wis 16 :cha 16}
+   :senses "passive Perception 17"
+   :size :huge
+   :type :giant
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-cloud-giant/keen-smell
+           :name "Keen Smell"
+           :desc "The giant has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-feature
+          {:id :creatures-cloud-giant/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The giant’s innate spellcasting ability is Charisma. It can innately cast the following spells, requiring no material components:"})
+        (provide-attr
+          [:attacks :creatures-cloud-giant/multiattack]
+          {:id :creatures-cloud-giant/multiattack
+           :name "Multiattack"
+           :desc "The giant makes two morningstar attacks."})
+        (provide-attr
+          [:attacks :creatures-cloud-giant/morningstar]
+          {:id :creatures-cloud-giant/morningstar
+           :name "Morningstar"
+           :desc "_Melee Weapon Attack: _+12 to hit, reach 10 ft., one target. _Hit: _21 (3d8 + 8) piercing damage."
+           :damage :piercing
+           :dice "3d8+8"
+           :to-hit 12})
+        (provide-attr
+          [:attacks :creatures-cloud-giant/rock]
+          {:id :creatures-cloud-giant/rock
+           :name "Rock"
+           :desc "_Ranged Weapon Attack: _+12 to hit, range 60/240 ft., one target. _Hit: _30 (4d10 + 8) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "4d10+8"
+           :to-hit 12}))}
+  {:id :creatures/fire-giant
+   :name "Fire Giant"
+   :ac 18
+   :challenge 9
+   :hit-points "13d12 + 78"
+   :abilities {:str 25 :dex 9 :con 23 :int 10 :wis 14 :cha 13}
+   :senses "passive Perception 16"
+   :size :huge
+   :type :giant
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-fire-giant/multiattack]
+          {:id :creatures-fire-giant/multiattack
+           :name "Multiattack"
+           :desc "The giant makes two greatsword attacks."})
+        (provide-attr
+          [:attacks :creatures-fire-giant/greatsword]
+          {:id :creatures-fire-giant/greatsword
+           :name "Greatsword"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 10 ft., one target. _Hit: _28 (6d6 + 7) slashing damage."
+           :damage :slashing
+           :dice "6d6+7"
+           :to-hit 11})
+        (provide-attr
+          [:attacks :creatures-fire-giant/rock]
+          {:id :creatures-fire-giant/rock
+           :name "Rock"
+           :desc "_Ranged Weapon Attack: _+11 to hit, range 60/240 ft., one target. _Hit: _29 (4d10 + 7) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "4d10+7"
+           :to-hit 11}))}
+  {:id :creatures/frost-giant
+   :name "Frost Giant"
+   :ac 15
+   :challenge 8
+   :hit-points "12d12 + 60"
+   :abilities {:str 23 :dex 9 :con 21 :int 9 :wis 10 :cha 12}
+   :senses "passive Perception 13"
+   :size :huge
+   :type :giant
+   :speed "40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-frost-giant/multiattack]
+          {:id :creatures-frost-giant/multiattack
+           :name "Multiattack"
+           :desc "The giant makes two greataxe attacks."})
+        (provide-attr
+          [:attacks :creatures-frost-giant/greataxe]
+          {:id :creatures-frost-giant/greataxe
+           :name "Greataxe"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 10 ft., one target. _Hit: _25 (3d12 + 6) slashing damage."
+           :damage :slashing
+           :dice "3d12+6"
+           :to-hit 9})
+        (provide-attr
+          [:attacks :creatures-frost-giant/rock]
+          {:id :creatures-frost-giant/rock
+           :name "Rock"
+           :desc "_Ranged Weapon Attack: _+9 to hit, range 60/240 ft., one target. _Hit: _28 (4d10 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "4d10+6"
+           :to-hit 9}))}
+  {:id :creatures/hill-giant
+   :name "Hill Giant"
+   :ac 13
+   :challenge 5
+   :hit-points "10d12 + 40"
+   :abilities {:str 21 :dex 8 :con 19 :int 5 :wis 9 :cha 6}
+   :senses "passive Perception 12"
+   :size :huge
+   :type :giant
+   :speed "40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-hill-giant/multiattack]
+          {:id :creatures-hill-giant/multiattack
+           :name "Multiattack"
+           :desc "The giant makes two greatclub attacks."})
+        (provide-attr
+          [:attacks :creatures-hill-giant/greatclub]
+          {:id :creatures-hill-giant/greatclub
+           :name "Greatclub"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 10 ft., one target. _Hit: _18 (3d8 + 5) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d8+5"
+           :to-hit 8})
+        (provide-attr
+          [:attacks :creatures-hill-giant/rock]
+          {:id :creatures-hill-giant/rock
+           :name "Rock"
+           :desc "_Ranged Weapon Attack: _+8 to hit, range 60/240 ft., one target. _Hit: _21 (3d10 + 5) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d10+5"
+           :to-hit 8}))}
+  {:id :creatures/stone-giant
+   :name "Stone Giant"
+   :ac 17
+   :challenge 7
+   :hit-points "11d12 + 55"
+   :abilities {:str 23 :dex 15 :con 20 :int 10 :wis 12 :cha 9}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :huge
+   :type :giant
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-stone-giant/stone-camouflage
+           :name "Stone Camouflage"
+           :desc "The giant has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."})
+        (provide-attr
+          [:attacks :creatures-stone-giant/multiattack]
+          {:id :creatures-stone-giant/multiattack
+           :name "Multiattack"
+           :desc "The giant makes two greatclub attacks."})
+        (provide-attr
+          [:attacks :creatures-stone-giant/greatclub]
+          {:id :creatures-stone-giant/greatclub
+           :name "Greatclub"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 15 ft., one target. _Hit: _19 (3d8 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d8+6"
+           :to-hit 9})
+        (provide-attr
+          [:attacks :creatures-stone-giant/rock]
+          {:id :creatures-stone-giant/rock
+           :name "Rock"
+           :desc "_Ranged Weapon Attack: _+9 to hit, range 60/240 ft., one target. _Hit: _28 (4d10 + 6) bludgeoning damage. If the target is a creature, it must succeed on a DC 17 Strength saving throw or be knocked prone."
+           :damage :bludgeoning
+           :dice "4d10+6"
+           :to-hit 9})
+        (provide-feature
+          {:id :creatures-stone-giant/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-stone-giant/rock-catching
+           :name "Rock Catching"
+           :desc "If a rock or similar object is hurled at the giant, the giant can, with a successful DC 10 Dexterity saving throw, catch the missile and take no bludgeoning damage from it."}))}
+  {:id :creatures/storm-giant
+   :name "Storm Giant"
+   :ac 16
+   :challenge 13
+   :hit-points "20d12 + 100"
+   :abilities {:str 29 :dex 14 :con 20 :int 16 :wis 18 :cha 18}
+   :senses "passive Perception 19"
+   :size :huge
+   :type :giant
+   :speed "50 ft., swim 50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-storm-giant/amphibious
+           :name "Amphibious"
+           :desc "The giant can breathe air and water."})
+        (provide-feature
+          {:id :creatures-storm-giant/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The giant’s innate spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:"})
+        (provide-attr
+          [:attacks :creatures-storm-giant/multiattack]
+          {:id :creatures-storm-giant/multiattack
+           :name "Multiattack"
+           :desc "The giant makes two greatsword attacks."})
+        (provide-attr
+          [:attacks :creatures-storm-giant/greatsword]
+          {:id :creatures-storm-giant/greatsword
+           :name "Greatsword"
+           :desc "_Melee Weapon Attack: _+14 to hit, reach 10 ft., one target. _Hit: _30 (6d6 + 9) slashing damage."
+           :damage :slashing
+           :dice "6d6+9"
+           :to-hit 14})
+        (provide-attr
+          [:attacks :creatures-storm-giant/rock]
+          {:id :creatures-storm-giant/rock
+           :name "Rock"
+           :desc "_Ranged Weapon Attack: _+14 to hit, range 60/240 ft., one target. _Hit: _35 (4d12 + 9) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "4d12+9"
+           :to-hit 14})
+        (provide-feature
+          {:id :creatures-storm-giant/lightning-strike
+           :name "Lightning Strike (Recharge 5–6)"
+           :desc "The giant hurls a magical lightning bolt at a point it can see within 500 feet of it. Each creature within 10 feet of that point must make a DC 17 Dexterity saving throw, taking 54 (12d8) lightning damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/gibbering-mouther
+   :name "Gibbering Mouther"
+   :ac 9
+   :challenge 2
+   :hit-points "9d8 + 27"
+   :abilities {:str 10 :dex 8 :con 16 :int 3 :wis 10 :cha 6}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :aberration
+   :speed "10 ft., swim 10 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gibbering-mouther/aberrant-ground
+           :name "Aberrant Ground"
+           :desc "The ground in a 10-foot radius around the mouther is doughlike difficult terrain. Each creature that starts its turn in that area must succeed on a DC 10 Strength saving throw or have its speed reduced to 0 until the start of its next turn."})
+        (provide-feature
+          {:id :creatures-gibbering-mouther/gibbering
+           :name "Gibbering"
+           :desc "The mouther babbles incoherently while it can see any creature and isn’t incapacitated. Each creature that starts its turn within 20 feet of the mouther and can hear the gibbering must succeed on a DC 10 Wisdom saving throw. On a failure, the creature can’t take reactions until the start of its next turn and rolls a d8 to determine what it does during its turn. On a 1 to 4, the creature does nothing. On a 5 or 6, the creature takes no action or bonus action and uses all its movement to move in a randomly determined direction. On a 7 or 8, the creature makes a melee attack against a randomly determined creature within its reach or does nothing if it can’t make such an attack."})
+        (provide-attr
+          [:attacks :creatures-gibbering-mouther/multiattack]
+          {:id :creatures-gibbering-mouther/multiattack
+           :name "Multiattack"
+           :desc "The gibbering mouther makes one bite attack and, if it can, uses its Blinding Spittle."})
+        (provide-attr
+          [:attacks :creatures-gibbering-mouther/bites]
+          {:id :creatures-gibbering-mouther/bites
+           :name "Bites"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one creature. _Hit: _17 (5d6) piercing damage. If the target is Medium or smaller, it must succeed on a DC 10 Strength saving throw or be knocked prone. If the target is killed by this damage, it is absorbed into the mouther."
+           :damage :piercing
+           :dice "5d6"
+           :to-hit 2})
+        (provide-feature
+          {:id :creatures-gibbering-mouther/blinding-spittle
+           :name "Blinding Spittle (Recharge 5–6)"
+           :desc "The mouther spits a chemical glob at a point it can see within 15 feet of it. The glob explodes in a blinding flash of light on impact. Each creature within 5 feet of the flash must succeed on a DC 13 Dexterity saving throw or be blinded until the end of the mouther’s next turn."}))}
+  {:id :creatures/gnoll
+   :name "Gnoll"
+   :ac 15
+   :challenge 0.5
+   :hit-points "5d8"
+   :abilities {:str 14 :dex 12 :con 11 :int 6 :wis 10 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gnoll/rampage
+           :name "Rampage"
+           :desc "When the gnoll reduces a creature to 0 hit points with a melee attack on its turn, the gnoll can take a bonus action to move up to half its speed and make a bite attack."})
+        (provide-attr
+          [:attacks :creatures-gnoll/bite]
+          {:id :creatures-gnoll/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _4 (1d4 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-gnoll/spear]
+          {:id :creatures-gnoll/spear
+           :name "Spear"
+           :desc "_Melee or Ranged Weapon Attack: _+4 to hit, reach 5 ft. or range 20/60 ft., one target. _Hit: _5 (1d6 + 2) piercing damage, or 6 (1d8 + 2) piercing damage if used with two hands to make a melee attack."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-gnoll/longbow]
+          {:id :creatures-gnoll/longbow
+           :name "Longbow"
+           :desc "_Ranged Weapon Attack: _+3 to hit, range 150/600 ft., one target. _Hit: _5 (1d8 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d8+1"
+           :to-hit 3}))}
+  {:id :creatures/gnome-deep-svirfneblin-
+   :name "Gnome, Deep (Svirfneblin)"
+   :ac 15
+   :challenge 0.5
+   :hit-points "3d6 + 6"
+   :abilities {:str 15 :dex 14 :con 14 :int 12 :wis 10 :cha 9}
+   :senses "darkvision 120 ft., passive Perception 12"
+   :size :small
+   :type :humanoid
+   :speed "20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gnome-deep-svirfneblin-/stone-camouflage
+           :name "Stone Camouflage"
+           :desc "The gnome has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."})
+        (provide-feature
+          {:id :creatures-gnome-deep-svirfneblin-/gnome-cunning
+           :name "Gnome Cunning"
+           :desc "The gnome has advantage on Intelligence, Wisdom, and Charisma saving throws against magic."})
+        (provide-feature
+          {:id :creatures-gnome-deep-svirfneblin-/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The gnome’s innate spellcasting ability is Intelligence (spell save DC 11). It can innately cast the following spells, requiring no material components:"})
+        (provide-attr
+          [:attacks :creatures-gnome-deep-svirfneblin-/war-pick]
+          {:id :creatures-gnome-deep-svirfneblin-/war-pick
+           :name "War Pick"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _6 (1d8 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-gnome-deep-svirfneblin-/poisoned-dart]
+          {:id :creatures-gnome-deep-svirfneblin-/poisoned-dart
+           :name "Poisoned Dart"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 30/120 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4}))}
+  {:id :creatures/goblin
+   :name "Goblin"
+   :ac 15
+   :challenge 0.25
+   :hit-points "2d6"
+   :abilities {:str 8 :dex 14 :con 10 :int 10 :wis 8 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 9"
+   :size :small
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-goblin/nimble-escape
+           :name "Nimble Escape"
+           :desc "The goblin can take the Disengage or Hide action as a bonus action on each of its turns."})
+        (provide-attr
+          [:attacks :creatures-goblin/scimitar]
+          {:id :creatures-goblin/scimitar
+           :name "Scimitar"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) slashing damage."
+           :damage :slashing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-goblin/shortbow]
+          {:id :creatures-goblin/shortbow
+           :name "Shortbow"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 80/320 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/clay-golem
+   :name "Clay Golem"
+   :ac 14
+   :challenge 9
+   :hit-points "14d10 + 56"
+   :abilities {:str 20 :dex 9 :con 18 :int 3 :wis 8 :cha 1}
+   :senses "darkvision 60 ft., passive Perception 9"
+   :size :large
+   :type :construct
+   :speed "20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-clay-golem/acid-absorption-
+           :name "Acid Absorption."
+           :desc "Whenever the golem is subjected to acid damage, it takes no damage and instead regains a number of hit points equal to the acid damage dealt."})
+        (provide-feature
+          {:id :creatures-clay-golem/berserk
+           :name "Berserk"
+           :desc "Whenever the golem starts its turn with 60 hit points or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its hit points."})
+        (provide-feature
+          {:id :creatures-clay-golem/immutable-form
+           :name "Immutable Form"
+           :desc "The golem is immune to any spell or effect that would alter its form."})
+        (provide-feature
+          {:id :creatures-clay-golem/magic-resistance
+           :name "Magic Resistance"
+           :desc "The golem has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-clay-golem/magic-weapons
+           :name "Magic Weapons"
+           :desc "The golem’s weapon attacks are magical."})
+        (provide-attr
+          [:attacks :creatures-clay-golem/multiattack]
+          {:id :creatures-clay-golem/multiattack
+           :name "Multiattack"
+           :desc "The golem makes two slam attacks."})
+        (provide-attr
+          [:attacks :creatures-clay-golem/slam]
+          {:id :creatures-clay-golem/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _16 (2d10 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the _greater restoration _spell or other magic."
+           :damage :bludgeoning
+           :dice "2d10+5"
+           :to-hit 8})
+        (provide-feature
+          {:id :creatures-clay-golem/haste
+           :name "Haste (Recharge 5–6)"
+           :desc "Until the end of its next turn, the golem magically gains a +2 bonus to its AC, has advantage on Dexterity saving throws, and can use its slam attack as a bonus action."}))}
+  {:id :creatures/flesh-golem
+   :name "Flesh Golem"
+   :ac 9
+   :challenge 5
+   :hit-points "11d8 + 44"
+   :abilities {:str 19 :dex 9 :con 18 :int 6 :wis 10 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :construct
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-flesh-golem/berserk
+           :name "Berserk"
+           :desc "Whenever the golem starts its turn with 40 hit points or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its hit points."})
+        (provide-attr
+          [:attacks :creatures-flesh-golem/multiattack]
+          {:id :creatures-flesh-golem/multiattack
+           :name "Multiattack"
+           :desc "The golem makes two slam attacks."})
+        (provide-attr
+          [:attacks :creatures-flesh-golem/slam]
+          {:id :creatures-flesh-golem/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+4"
+           :to-hit 7}))}
+  {:id :creatures/iron-golem
+   :name "Iron Golem"
+   :ac 20
+   :challenge 16
+   :hit-points "20d10 + 100"
+   :abilities {:str 24 :dex 9 :con 20 :int 3 :wis 11 :cha 1}
+   :senses "darkvision 120 ft., passive Perception 10"
+   :size :large
+   :type :construct
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-iron-golem/fire-absorption-
+           :name "Fire Absorption."
+           :desc "Whenever the golem is subjected to fire damage, it takes no damage and instead regains a number of hit points equal to the fire damage dealt."})
+        (provide-feature
+          {:id :creatures-iron-golem/immutable-form
+           :name "Immutable Form"
+           :desc "The golem is immune to any spell or effect that would alter its form."})
+        (provide-feature
+          {:id :creatures-iron-golem/magic-resistance
+           :name "Magic Resistance"
+           :desc "The golem has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-iron-golem/magic-weapons
+           :name "Magic Weapons"
+           :desc "The golem’s weapon attacks are magical."})
+        (provide-attr
+          [:attacks :creatures-iron-golem/multiattack]
+          {:id :creatures-iron-golem/multiattack
+           :name "Multiattack"
+           :desc "The golem makes two melee attacks."})
+        (provide-attr
+          [:attacks :creatures-iron-golem/slam]
+          {:id :creatures-iron-golem/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 5 ft., one target. _Hit: _20 (3d8 + 7) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d8+7"
+           :to-hit 13})
+        (provide-attr
+          [:attacks :creatures-iron-golem/sword]
+          {:id :creatures-iron-golem/sword
+           :name "Sword"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 10 ft., one target. _Hit: _23 (3d10 + 7) slashing damage."
+           :damage :slashing
+           :dice "3d10+7"
+           :to-hit 13})
+        (provide-feature
+          {:id :creatures-iron-golem/poison-breath
+           :name "Poison Breath (Recharge 6)"
+           :desc "The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/stone-golem
+   :name "Stone Golem"
+   :ac 17
+   :challenge 10
+   :hit-points "17d10 + 85"
+   :abilities {:str 22 :dex 9 :con 20 :int 3 :wis 11 :cha 1}
+   :senses "darkvision 120 ft., passive Perception 10"
+   :size :large
+   :type :construct
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-stone-golem/immutable-form
+           :name "Immutable Form"
+           :desc "The golem is immune to any spell or effect that would alter its form."})
+        (provide-feature
+          {:id :creatures-stone-golem/magic-resistance
+           :name "Magic Resistance"
+           :desc "The golem has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-stone-golem/magic-weapons
+           :name "Magic Weapons"
+           :desc "The golem’s weapon attacks are magical."})
+        (provide-attr
+          [:attacks :creatures-stone-golem/multiattack]
+          {:id :creatures-stone-golem/multiattack
+           :name "Multiattack"
+           :desc "The golem makes two slam attacks."})
+        (provide-attr
+          [:attacks :creatures-stone-golem/slam]
+          {:id :creatures-stone-golem/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one target. _Hit: _19 (3d8 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d8+6"
+           :to-hit 10})
+        (provide-feature
+          {:id :creatures-stone-golem/slow
+           :name "Slow (Recharge 5–6)"
+           :desc "The golem targets one or more creatures it can see within 10 feet of it. Each target must make a DC 17 Wisdom saving throw against this magic. On a failed save, a target can’t use reactions, its speed is halved, and it can’t make more than one attack on its turn. In addition, the target can take either an action or a bonus action on its turn, not both. These effects last for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."}))}
+  {:id :creatures/gorgon
+   :name "Gorgon"
+   :ac 19
+   :challenge 5
+   :hit-points "12d10 + 48"
+   :abilities {:str 20 :dex 11 :con 18 :int 2 :wis 12 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :large
+   :type :monstrosity
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gorgon/trampling-charge
+           :name "Trampling Charge"
+           :desc "If the gorgon moves at least 20 feet straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 16 Strength saving throw or be knocked prone. If the target is prone, the gorgon can make one attack with its hooves against it as a bonus action."})
+        (provide-attr
+          [:attacks :creatures-gorgon/gore]
+          {:id :creatures-gorgon/gore
+           :name "Gore"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _18 (2d12 + 5) piercing damage."
+           :damage :piercing
+           :dice "2d12+5"
+           :to-hit 8})
+        (provide-attr
+          [:attacks :creatures-gorgon/hooves]
+          {:id :creatures-gorgon/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _16 (2d10 + 5) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d10+5"
+           :to-hit 8})
+        (provide-feature
+          {:id :creatures-gorgon/petrifying-breath
+           :name "Petrifying Breath (Recharge 5–6)"
+           :desc "The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must succeed on a DC 13 Constitution saving throw. On a failed save, a target begins to turn to stone and is restrained. The restrained target must repeat the saving throw at the end of its next turn. On a success, the effect ends on the target. On a failure, the target is petrified until freed by the _greater restoration _spell or other magic."}))}
+  {:id :creatures/grick
+   :name "Grick"
+   :ac 14
+   :challenge 2
+   :hit-points "6d8"
+   :abilities {:str 14 :dex 14 :con 11 :int 3 :wis 14 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 12"
+   :size :medium
+   :type :monstrosity
+   :speed "30 ft., climb 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-grick/stone-camouflage
+           :name "Stone Camouflage"
+           :desc "The grick has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."})
+        (provide-attr
+          [:attacks :creatures-grick/multiattack]
+          {:id :creatures-grick/multiattack
+           :name "Multiattack"
+           :desc "The grick makes one attack with its tentacles. If that attack hits, the grick can make one beak attack against the same target."})
+        (provide-attr
+          [:attacks :creatures-grick/tentacles]
+          {:id :creatures-grick/tentacles
+           :name "Tentacles"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _9 (2d6 + 2) slashing damage."
+           :damage :slashing
+           :dice "2d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-grick/beak]
+          {:id :creatures-grick/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/griffon
+   :name "Griffon"
+   :ac 12
+   :challenge 2
+   :hit-points "7d10 + 21"
+   :abilities {:str 18 :dex 15 :con 16 :int 2 :wis 13 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 15"
+   :size :large
+   :type :monstrosity
+   :speed "30 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-griffon/keen-sight
+           :name "Keen Sight"
+           :desc "The griffon has advantage on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-griffon/multiattack]
+          {:id :creatures-griffon/multiattack
+           :name "Multiattack"
+           :desc "The griffon makes two attacks: one with its beak and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-griffon/beak]
+          {:id :creatures-griffon/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _8 (1d8 + 4) piercing damage."
+           :damage :piercing
+           :dice "1d8+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-griffon/claws]
+          {:id :creatures-griffon/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 6}))}
+  {:id :creatures/grimlock
+   :name "Grimlock"
+   :ac 11
+   :challenge 0.25
+   :hit-points "2d8 + 2"
+   :abilities {:str 16 :dex 12 :con 12 :int 9 :wis 8 :cha 6}
+   :senses "blindsight 30 ft. or 10 ft. while deafened (blind beyond this radius), passive Perception 13"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-grimlock/blind-senses
+           :name "Blind Senses"
+           :desc "The grimlock can’t use its blindsight while deafened and unable to smell."})
+        (provide-feature
+          {:id :creatures-grimlock/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The grimlock has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-feature
+          {:id :creatures-grimlock/stone-camouflage
+           :name "Stone Camouflage"
+           :desc "The grimlock has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."})
+        (provide-attr
+          [:attacks :creatures-grimlock/spiked-bone-club]
+          {:id :creatures-grimlock/spiked-bone-club
+           :name "Spiked Bone Club"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _5 (1d4 + 3) bludgeoning damage plus 2 (1d4) piercing damage."
+           :damage :bludgeoning
+           :dice "1d4+3"
+           :to-hit 5}))}
+  {:id :creatures/green-hag
+   :name "Green Hag"
+   :ac 17
+   :challenge 3
+   :hit-points "11d8 + 33"
+   :abilities {:str 18 :dex 12 :con 16 :int 13 :wis 14 :cha 14}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :fey
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-green-hag/amphibious
+           :name "Amphibious"
+           :desc "The hag can breathe air and water."})
+        (provide-feature
+          {:id :creatures-green-hag/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The hag’s innate spellcasting ability is Charisma (spell save DC 12). She can innately cast the following spells, requiring no material components:"})
+        (provide-feature
+          {:id :creatures-green-hag/mimicry
+           :name "Mimicry"
+           :desc "The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations with a successful DC 14 Wisdom (Insight) check."})
+        (provide-attr
+          [:attacks :creatures-green-hag/claws]
+          {:id :creatures-green-hag/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d8+4"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-green-hag/illusory-appearance
+           :name "Illusory Appearance"
+           :desc "The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like another creature of her general size and humanoid shape. The illusion ends if the hag takes a bonus action to end it or if she dies."}))}
+  {:id :creatures/night-hag
+   :name "Night Hag"
+   :ac 17
+   :challenge 5
+   :hit-points "15d8 + 45"
+   :abilities {:str 18 :dex 15 :con 16 :int 16 :wis 14 :cha 16}
+   :senses "darkvision 120 ft., passive Perception 16"
+   :size :medium
+   :type :fiend
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-night-hag/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The hag’s innate spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks). She can innately cast the following spells, requiring no material components:"})
+        (provide-feature
+          {:id :creatures-night-hag/magic-resistance
+           :name "Magic Resistance"
+           :desc "The hag has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-night-hag/claws]
+          {:id :creatures-night-hag/claws
+           :name "Claws (Hag Form Only)"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d8+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-night-hag/change-shape
+           :name "Change Shape"
+           :desc "The hag magically polymorphs into a Small or Medium female humanoid, or back into her true form. Her statistics are the same in each form. Any equipment she is wearing or carrying isn’t transformed. She reverts to her true form if she dies."})
+        (provide-feature
+          {:id :creatures-night-hag/etherealness
+           :name "Etherealness"
+           :desc "The hag magically enters the Ethereal Plane from the Material Plane, or vice versa. To do so, the hag must have a _heartstone _in her possession."})
+        (provide-feature
+          {:id :creatures-night-hag/nightmare-haunting
+           :name "Nightmare Haunting (1/Day)"
+           :desc "While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. A _protection from evil and good _spell cast on the target prevents this contact, as does a _magic circle._ As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 (1d10). If this effect reduces the target’s hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the hag’s _soul bag._ The reduction to the target’s hit point maximum lasts until removed by the _greater restoration _spell or similar magic."}))}
+  {:id :creatures/sea-hag
+   :name "Sea Hag"
+   :ac 14
+   :challenge 2
+   :hit-points "7d8 + 21"
+   :abilities {:str 16 :dex 13 :con 16 :int 12 :wis 12 :cha 13}
+   :senses "darkvision 60 ft., passive Perception 11"
+   :size :medium
+   :type :fey
+   :speed "30 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-sea-hag/amphibious
+           :name "Amphibious"
+           :desc "The hag can breathe air and water."})
+        (provide-feature
+          {:id :creatures-sea-hag/horrific-appearance
+           :name "Horrific Appearance"
+           :desc "Any humanoid that starts its turn within 30 feet of the hag and can see the hag’s true form must make a DC 11 Wisdom saving throw. On a failed save, the creature is frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, with disadvantage if the hag is within line of sight, ending the effect"})
+        (provide-attr
+          [:attacks :creatures-sea-hag/claws]
+          {:id :creatures-sea-hag/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "2d6+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-sea-hag/death-glare
+           :name "Death Glare"
+           :desc "The hag targets one frightened creature she can see within 30 feet of her. If the target can see the hag, it must succeed on a DC 11 Wisdom saving throw against this magic or drop to 0 hit points."})
+        (provide-feature
+          {:id :creatures-sea-hag/illusory-appearance
+           :name "Illusory Appearance"
+           :desc "The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like an ugly creature of her general size and humanoid shape. The effect ends if the hag takes a bonus action to end it or if she dies."}))}
+  {:id :creatures/half-red-dragon-veteran
+   :name "Half-Red Dragon Veteran"
+   :ac 18
+   :challenge 5
+   :hit-points "10d8 + 20"
+   :abilities {:str 16 :dex 13 :con 14 :int 10 :wis 11 :cha 10}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 12"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-half-red-dragon-veteran/multiattack]
+          {:id :creatures-half-red-dragon-veteran/multiattack
+           :name "Multiattack"
+           :desc "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."})
+        (provide-attr
+          [:attacks :creatures-half-red-dragon-veteran/longsword]
+          {:id :creatures-half-red-dragon-veteran/longsword
+           :name "Longsword"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands."
+           :damage :slashing
+           :dice "1d8+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-half-red-dragon-veteran/shortsword]
+          {:id :creatures-half-red-dragon-veteran/shortsword
+           :name "Shortsword"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-half-red-dragon-veteran/heavy-crossbow]
+          {:id :creatures-half-red-dragon-veteran/heavy-crossbow
+           :name "Heavy Crossbow"
+           :desc "_Ranged Weapon Attack: _+3 to hit, range 100/400 ft., one target. _Hit: _6 (1d10 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d10+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-half-red-dragon-veteran/fire-breath
+           :name "Fire Breath (Recharge 5–6)"
+           :desc "The veteran exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/harpy
+   :name "Harpy"
+   :ac 11
+   :challenge 1
+   :hit-points "7d8 + 7"
+   :abilities {:str 12 :dex 13 :con 12 :int 7 :wis 10 :cha 13}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :monstrosity
+   :speed "20 ft., fly 40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-harpy/multiattack]
+          {:id :creatures-harpy/multiattack
+           :name "Multiattack"
+           :desc "The harpy makes two attacks: one with its claws and one with its club."})
+        (provide-attr
+          [:attacks :creatures-harpy/claws]
+          {:id :creatures-harpy/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _6 (2d4 + 1) slashing damage."
+           :damage :slashing
+           :dice "2d4+1"
+           :to-hit 3})
+        (provide-attr
+          [:attacks :creatures-harpy/club]
+          {:id :creatures-harpy/club
+           :name "Club"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _3 (1d4 + 1) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d4+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-harpy/luring-song
+           :name "Luring Song"
+           :desc "The harpy sings a magical melody. Every humanoid and giant within 300 feet of the harpy that can hear the song must succeed on a DC 11 Wisdom saving throw or be charmed until the song ends. The harpy must take a bonus action on its subsequent turns to continue singing. It can stop singing at any time. The song ends if the harpy is incapacitated."}))}
+  {:id :creatures/hell-hound
+   :name "Hell Hound"
+   :ac 15
+   :challenge 3
+   :hit-points "7d8 + 14"
+   :abilities {:str 17 :dex 12 :con 14 :int 6 :wis 13 :cha 6}
+   :senses "darkvision 60 ft., passive Perception 15"
+   :size :medium
+   :type :fiend
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-hell-hound/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The hound has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-feature
+          {:id :creatures-hell-hound/pack-tactics
+           :name "Pack Tactics"
+           :desc "The hound has advantage on an attack roll against a creature if at least one of the hound’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-hell-hound/bite]
+          {:id :creatures-hell-hound/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) piercing damage plus 7 (2d6) fire damage."
+           :damage :piercing
+           :dice "1d8+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-hell-hound/fire-breath
+           :name "Fire Breath (Recharge 5–6)"
+           :desc "The hound exhales fire in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 21 (6d6) fire damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/hippogriff
+   :name "Hippogriff"
+   :ac 11
+   :challenge 1
+   :hit-points "3d10 + 3"
+   :abilities {:str 17 :dex 13 :con 13 :int 2 :wis 12 :cha 8}
+   :senses "passive Perception 15"
+   :size :large
+   :type :monstrosity
+   :speed "40 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-hippogriff/keen-sight
+           :name "Keen Sight"
+           :desc "The hippogriff has advantage on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-hippogriff/multiattack]
+          {:id :creatures-hippogriff/multiattack
+           :name "Multiattack"
+           :desc "The hippogriff makes two attacks: one with its beak and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-hippogriff/beak]
+          {:id :creatures-hippogriff/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _8 (1d10 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d10+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-hippogriff/claws]
+          {:id :creatures-hippogriff/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/hobgoblin
+   :name "Hobgoblin"
+   :ac 18
+   :challenge 0.5
+   :hit-points "2d8 + 2"
+   :abilities {:str 13 :dex 12 :con 12 :int 10 :wis 10 :cha 9}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-hobgoblin/martial-advantage
+           :name "Martial Advantage"
+           :desc "Once per turn, the hobgoblin can deal an extra 7 (2d6) damage to a creature it hits with a weapon attack if that creature is within 5 feet of an ally of the hobgoblin that isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-hobgoblin/longsword]
+          {:id :creatures-hobgoblin/longsword
+           :name "Longsword"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _5 (1d8 + 1) slashing damage, or 6 (1d10 + 1) slashing damage if used with two hands."
+           :damage :slashing
+           :dice "1d8+1"
+           :to-hit 3})
+        (provide-attr
+          [:attacks :creatures-hobgoblin/longbow]
+          {:id :creatures-hobgoblin/longbow
+           :name "Longbow"
+           :desc "_Ranged Weapon Attack: _+3 to hit, range 150/600 ft., one target. _Hit: _5 (1d8 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d8+1"
+           :to-hit 3}))}
+  {:id :creatures/homunculus
+   :name "Homunculus"
+   :ac 13
+   :challenge 0
+   :hit-points "2d4"
+   :abilities {:str 4 :dex 15 :con 11 :int 10 :wis 10 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :tiny
+   :type :construct
+   :speed "20 ft., fly 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-homunculus/telepathic-bond
+           :name "Telepathic Bond"
+           :desc "While the homunculus is on the same plane of existence as its master, it can magically convey what it senses to its master, and the two can communicate telepathically."})
+        (provide-attr
+          [:attacks :creatures-homunculus/bite]
+          {:id :creatures-homunculus/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or be poisoned for 1 minute. If the saving throw fails by 5 or more, the target is instead poisoned for 5 (1d10) minutes and unconscious while poisoned in this way."
+           :to-hit 4}))}
+  {:id :creatures/hydra
+   :name "Hydra"
+   :ac 15
+   :challenge 8
+   :hit-points "15d12 + 75"
+   :abilities {:str 20 :dex 12 :con 20 :int 2 :wis 10 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 16"
+   :size :huge
+   :type :monstrosity
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-hydra/hold-breath
+           :name "Hold Breath"
+           :desc "The hydra can hold its breath for 1 hour."})
+        (provide-feature
+          {:id :creatures-hydra/multiple-heads
+           :name "Multiple Heads"
+           :desc "The hydra has five heads. While it has more than one head, the hydra has advantage on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious."})
+        (provide-feature
+          {:id :creatures-hydra/wakeful
+           :name "Wakeful"
+           :desc "While the hydra sleeps, at least one of its heads is awake."})
+        (provide-attr
+          [:attacks :creatures-hydra/multiattack]
+          {:id :creatures-hydra/multiattack
+           :name "Multiattack"
+           :desc "The hydra makes as many bite attacks as it has heads."})
+        (provide-attr
+          [:attacks :creatures-hydra/bite]
+          {:id :creatures-hydra/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 10 ft., one target. _Hit: _10 (1d10 + 5) piercing damage."
+           :damage :piercing
+           :dice "1d10+5"
+           :to-hit 8}))}
+  {:id :creatures/invisible-stalker
+   :name "Invisible Stalker"
+   :ac 14
+   :challenge 6
+   :hit-points "16d8 + 32"
+   :abilities {:str 16 :dex 19 :con 14 :int 10 :wis 15 :cha 11}
+   :senses "darkvision 60 ft., passive Perception 18"
+   :size :medium
+   :type :elemental
+   :speed "50 ft., fly 50 ft. (hover)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-invisible-stalker/invisibility
+           :name "Invisibility"
+           :desc "The stalker is invisible."})
+        (provide-feature
+          {:id :creatures-invisible-stalker/faultless-tracker
+           :name "Faultless Tracker"
+           :desc "The stalker is given a quarry by its summoner. The stalker knows the direction and distance to its quarry as long as the two of them are on the same plane of existence. The stalker also knows the location of its summoner."})
+        (provide-attr
+          [:attacks :creatures-invisible-stalker/multiattack]
+          {:id :creatures-invisible-stalker/multiattack
+           :name "Multiattack"
+           :desc "The stalker makes two slam attacks."})
+        (provide-attr
+          [:attacks :creatures-invisible-stalker/slam]
+          {:id :creatures-invisible-stalker/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d6+3"
+           :to-hit 6}))}
+  {:id :creatures/kobold
+   :name "Kobold"
+   :ac 12
+   :challenge 0.125
+   :hit-points "2d6 − 2"
+   :abilities {:str 7 :dex 15 :con 9 :int 8 :wis 7 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 8"
+   :size :small
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-kobold/sunlight-sensitivity
+           :name "Sunlight Sensitivity"
+           :desc "While in sunlight, the kobold has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."})
+        (provide-feature
+          {:id :creatures-kobold/pack-tactics
+           :name "Pack Tactics"
+           :desc "The kobold has advantage on an attack roll against a creature if at least one of the kobold’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-kobold/dagger]
+          {:id :creatures-kobold/dagger
+           :name "Dagger"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _4 (1d4 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-kobold/sling]
+          {:id :creatures-kobold/sling
+           :name "Sling"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 30/120 ft., one target. _Hit: _4 (1d4 + 2) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d4+2"
+           :to-hit 4}))}
+  {:id :creatures/lamia
+   :name "Lamia"
+   :ac 13
+   :challenge 4
+   :hit-points "13d10 + 26"
+   :abilities {:str 16 :dex 13 :con 15 :int 14 :wis 15 :cha 16}
+   :senses "darkvision 60 ft., passive Perception 12"
+   :size :large
+   :type :monstrosity
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-lamia/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The lamia’s innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components. At will: _disguise self _(any humanoid form), _major image _3/day each: _charm person,_ _mirror image,_ _scrying,_ _suggestion _1/day: _geas_"})
+        (provide-attr
+          [:attacks :creatures-lamia/multiattack]
+          {:id :creatures-lamia/multiattack
+           :name "Multiattack"
+           :desc "The lamia makes two attacks: one with its claws and one with its dagger or Intoxicating Touch."})
+        (provide-attr
+          [:attacks :creatures-lamia/claws]
+          {:id :creatures-lamia/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _14 (2d10 + 3) slashing damage."
+           :damage :slashing
+           :dice "2d10+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-lamia/dagger]
+          {:id :creatures-lamia/dagger
+           :name "Dagger"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _5 (1d4 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d4+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-lamia/intoxicating-touch]
+          {:id :creatures-lamia/intoxicating-touch
+           :name "Intoxicating Touch"
+           :desc "_Melee Spell Attack: _+5 to hit, reach 5 ft., one creature. _Hit: _The target is magically cursed for 1 hour. Until the curse ends, the target has disadvantage on Wisdom saving throws and all ability checks."
+           :to-hit 5}))}
+  {:id :creatures/lich
+   :name "Lich"
+   :ac 17
+   :challenge 21
+   :hit-points "18d8 + 54"
+   :abilities {:str 11 :dex 16 :con 16 :int 20 :wis 14 :cha 16}
+   :senses "truesight 120 ft., passive Perception 19"
+   :size :medium
+   :type :undead
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-lich/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the lich fails a saving throw, it can choose to succeed instead."})
+        (provide-feature
+          {:id :creatures-lich/rejuvenation
+           :name "Rejuvenation"
+           :desc "If it has a phylactery, a destroyed lich gains a new body in 1d10 days, regaining all its hit points and becoming active again. The new body appears within 5 feet of the phylactery."})
+        (provide-feature
+          {:id :creatures-lich/spellcasting
+           :name "Spellcasting"
+           :desc "The lich is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20, +12 to hit with spell attacks). The lich has the following wizard spells prepared:"})
+        (provide-feature
+          {:id :creatures-lich/turn-resistance
+           :name "Turn Resistance"
+           :desc "The lich has advantage on saving throws against any effect that turns undead."})
+        (provide-attr
+          [:attacks :creatures-lich/paralyzing-touch]
+          {:id :creatures-lich/paralyzing-touch
+           :name "Paralyzing Touch"
+           :desc "_Melee Spell Attack: _+12 to hit, reach 5 ft., one creature. _Hit: _10 (3d6) cold damage. The target must succeed on a DC 18 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+           :damage :cold
+           :dice "3d6"
+           :to-hit 12})
+        (provide-feature
+          {:id :creatures-lich/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-lich/cantrip
+           :name "Cantrip"
+           :desc "The lich casts a cantrip."})
+        (provide-feature
+          {:id :creatures-lich/paralyzing-touch
+           :name "Paralyzing Touch (Costs 2 Actions)"
+           :desc "The lich uses its Paralyzing Touch."})
+        (provide-feature
+          {:id :creatures-lich/frightening-gaze
+           :name "Frightening Gaze (Costs 2 Actions)"
+           :desc "The lich fixes its gaze on one creature it can see within 10 feet of it. The target must succeed on a DC 18 Wisdom saving throw against this magic or become frightened for 1 minute. The frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target’s saving throw is successful or the effect ends for it, the target is immune to the lich’s gaze for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-lich/disrupt-life
+           :name "Disrupt Life (Costs 3 Actions)"
+           :desc "Each non-undead creature within 20 feet of the lich must make a DC 18 Constitution saving throw against this magic, taking 21 (6d6) necrotic damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/lizardfolk
+   :name "Lizardfolk"
+   :ac 15
+   :challenge 0.5
+   :hit-points "4d8 + 4"
+   :abilities {:str 15 :dex 10 :con 13 :int 7 :wis 12 :cha 7}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-lizardfolk/hold-breath
+           :name "Hold Breath"
+           :desc "The lizardfolk can hold its breath for 15 minutes."})
+        (provide-attr
+          [:attacks :creatures-lizardfolk/multiattack]
+          {:id :creatures-lizardfolk/multiattack
+           :name "Multiattack"
+           :desc "The lizardfolk makes two melee attacks, each one with a different weapon."})
+        (provide-attr
+          [:attacks :creatures-lizardfolk/bite]
+          {:id :creatures-lizardfolk/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-lizardfolk/heavy-club]
+          {:id :creatures-lizardfolk/heavy-club
+           :name "Heavy Club"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-lizardfolk/javelin]
+          {:id :creatures-lizardfolk/javelin
+           :name "Javelin"
+           :desc "_Melee or Ranged Weapon Attack: _+4 to hit, reach 5 ft. or range 30/120 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-lizardfolk/spiked-shield]
+          {:id :creatures-lizardfolk/spiked-shield
+           :name "Spiked Shield"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/werebear
+   :name "Werebear"
+   :ac 10
+   :challenge 5
+   :hit-points "18d8 + 54"
+   :abilities {:str 19 :dex 10 :con 17 :int 11 :wis 12 :cha 12}
+   :senses "passive Perception 17"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft. (40 ft., climb 30 ft. in bear or hybrid form)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-werebear/shapechanger
+           :name "Shapechanger"
+           :desc "The werebear can use its action to polymorph into a Large bear-humanoid hybrid or into a Large bear, or back into its true form, which is humanoid. Its statistics, other than its size and AC, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-feature
+          {:id :creatures-werebear/keen-smell
+           :name "Keen Smell"
+           :desc "The werebear has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-attr
+          [:attacks :creatures-werebear/multiattack]
+          {:id :creatures-werebear/multiattack
+           :name "Multiattack"
+           :desc "In bear form, the werebear makes two claw attacks. In humanoid form, it makes two greataxe attacks. In hybrid form, it can attack like a bear or a humanoid."})
+        (provide-attr
+          [:attacks :creatures-werebear/bite]
+          {:id :creatures-werebear/bite
+           :name "Bite (Bear or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _15 (2d10 + 4) piercing damage. If the target is a humanoid, it must succeed on a DC 14 Constitution saving throw or be cursed with werebear lycanthropy."
+           :damage :piercing
+           :dice "2d10+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-werebear/claw]
+          {:id :creatures-werebear/claw
+           :name "Claw (Bear or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d8+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-werebear/greataxe]
+          {:id :creatures-werebear/greataxe
+           :name "Greataxe (Humanoid or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit:_"
+           :to-hit 7}))}
+  {:id :creatures/wereboar
+   :name "Wereboar"
+   :ac 10
+   :challenge 4
+   :hit-points "12d8 + 24"
+   :abilities {:str 17 :dex 10 :con 15 :int 10 :wis 11 :cha 8}
+   :senses "passive Perception 12"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft. (40 ft. in boar form)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-wereboar/shapechanger
+           :name "Shapechanger"
+           :desc "The wereboar can use its action to polymorph into a boar-humanoid hybrid or into a boar, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-feature
+          {:id :creatures-wereboar/charge
+           :name "Charge (Boar or Hybrid Form Only)"
+           :desc "If the wereboar moves at least 15 feet straight toward a target and then hits it with its tusks on the same turn, the target takes an extra 7 (2d6) slashing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."})
+        (provide-feature
+          {:id :creatures-wereboar/relentless
+           :name "Relentless (Recharges after a Short or Long Rest)"
+           :desc "If the wereboar takes 14 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."})
+        (provide-feature
+          {:id :creatures-wereboar/multiattack
+           :name "Multiattack (Humanoid or Hybrid Form Only)"
+           :desc "The wereboar makes two attacks, only one of which can be with its tusks."})
+        (provide-attr
+          [:attacks :creatures-wereboar/maul]
+          {:id :creatures-wereboar/maul
+           :name "Maul (Humanoid or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit:_"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-wereboar/tusks]
+          {:id :creatures-wereboar/tusks
+           :name "Tusks (Boar or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) slashing damage. If the target is a humanoid, it must succeed on a DC 12 Constitution saving throw or be cursed with wereboar lycanthropy."
+           :damage :slashing
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/wererat
+   :name "Wererat"
+   :ac 12
+   :challenge 2
+   :hit-points "6d8 + 6"
+   :abilities {:str 10 :dex 15 :con 12 :int 11 :wis 10 :cha 8}
+   :senses "darkvision 60 ft. (rat form only), passive Perception 12"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-wererat/shapechanger
+           :name "Shapechanger"
+           :desc "The wererat can use its action to polymorph into a rat-humanoid hybrid or into a giant rat, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-feature
+          {:id :creatures-wererat/keen-smell
+           :name "Keen Smell"
+           :desc "The wererat has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-feature
+          {:id :creatures-wererat/multiattack
+           :name "Multiattack (Humanoid or Hybrid Form Only)"
+           :desc "The wererat makes two attacks, only one of which can be a bite."})
+        (provide-attr
+          [:attacks :creatures-wererat/bite]
+          {:id :creatures-wererat/bite
+           :name "Bite (Rat or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack:_"})
+        (provide-attr
+          [:attacks :creatures-wererat/shortsword]
+          {:id :creatures-wererat/shortsword
+           :name "Shortsword (Humanoid or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-wererat/hand-crossbow]
+          {:id :creatures-wererat/hand-crossbow
+           :name "Hand Crossbow (Humanoid or Hybrid Form Only)"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 30/120 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/weretiger
+   :name "Weretiger"
+   :ac 12
+   :challenge 4
+   :hit-points "16d8 + 48"
+   :abilities {:str 17 :dex 15 :con 16 :int 10 :wis 13 :cha 11}
+   :senses "darkvision 60 ft., passive Perception 15"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft. (40 ft. in tiger form)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-weretiger/shapechanger
+           :name "Shapechanger"
+           :desc "The weretiger can use its action to polymorph into a tiger-humanoid hybrid or into a tiger, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-feature
+          {:id :creatures-weretiger/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The weretiger has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-feature
+          {:id :creatures-weretiger/pounce
+           :name "Pounce (Tiger or Hybrid Form Only)"
+           :desc "If the weretiger moves at least 15 feet straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone**. **If the target is prone, the weretiger can make one bite attack against it as a bonus action."})
+        (provide-feature
+          {:id :creatures-weretiger/multiattack
+           :name "Multiattack (Humanoid or Hybrid Form Only)"
+           :desc "In humanoid form, the weretiger makes two scimitar attacks or two longbow attacks. In hybrid form, it can attack like a humanoid or make two claw attacks."})
+        (provide-attr
+          [:attacks :creatures-weretiger/bite]
+          {:id :creatures-weretiger/bite
+           :name "Bite (Tiger or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage. If the target is a humanoid, it must succeed on a DC 13 Constitution saving throw or be cursed with weretiger lycanthropy."
+           :damage :piercing
+           :dice "1d10+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-weretiger/claw]
+          {:id :creatures-weretiger/claw
+           :name "Claw (Tiger or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d8+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-weretiger/scimitar]
+          {:id :creatures-weretiger/scimitar
+           :name "Scimitar (Humanoid or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-weretiger/longbow]
+          {:id :creatures-weretiger/longbow
+           :name "Longbow (Humanoid or Hybrid Form Only)"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 150/600 ft., one target. _Hit: _6 (1d8 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 4}))}
+  {:id :creatures/werewolf
+   :name "Werewolf"
+   :ac 11
+   :challenge 3
+   :hit-points "9d8 + 18"
+   :abilities {:str 15 :dex 13 :con 14 :int 10 :wis 11 :cha 10}
+   :senses "passive Perception 14"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft. (40 ft. in wolf form)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-werewolf/shapechanger
+           :name "Shapechanger"
+           :desc "The werewolf can use its action to polymorph into a wolf-humanoid hybrid or into a wolf, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-feature
+          {:id :creatures-werewolf/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The werewolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-feature
+          {:id :creatures-werewolf/multiattack
+           :name "Multiattack (Humanoid or Hybrid Form Only)"
+           :desc "The werewolf makes two attacks: one with its bite and one with its claws or spear."})
+        (provide-attr
+          [:attacks :creatures-werewolf/bite]
+          {:id :creatures-werewolf/bite
+           :name "Bite (Wolf or Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _6 (1d8 + 2) piercing damage. If the target is a humanoid, it must succeed on a DC 12 Constitution saving throw or be cursed with werewolf lycanthropy."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-werewolf/claws]
+          {:id :creatures-werewolf/claws
+           :name "Claws (Hybrid Form Only)"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _7 (2d4 + 2) slashing damage."
+           :damage :slashing
+           :dice "2d4+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-werewolf/spear]
+          {:id :creatures-werewolf/spear
+           :name "Spear (Humanoid Form Only)"
+           :desc "_Melee or Ranged Weapon Attack: _+4 to hit, reach 5 ft. or range 20/60 ft., one creature. _Hit: _5 (1d6 + 2) piercing damage, or 6 (1d8 + 2) piercing damage if used with two hands to make a melee attack."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/magmin
+   :name "Magmin"
+   :ac 14
+   :challenge 0.5
+   :hit-points "2d6 + 2"
+   :abilities {:str 7 :dex 15 :con 12 :int 8 :wis 11 :cha 10}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :small
+   :type :elemental
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-magmin/death-burst
+           :name "Death Burst"
+           :desc "When the magmin dies, it explodes in a burst of fire and magma. Each creature within 10 feet of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one. Flammable objects that aren’t being worn or carried in that area are ignited."})
+        (provide-feature
+          {:id :creatures-magmin/ignited-illumination
+           :name "Ignited Illumination"
+           :desc "As a bonus action, the magmin can set itself ablaze or extinguish its flames. While ablaze, the magmin sheds bright light in a 10-foot radius and dim light for an additional 10 feet."})
+        (provide-attr
+          [:attacks :creatures-magmin/touch]
+          {:id :creatures-magmin/touch
+           :name "Touch"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (2d6) fire damage. If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes 3 (1d6) fire damage at the end of each of its turns."
+           :damage :fire
+           :dice "2d6"
+           :to-hit 4}))}
+  {:id :creatures/manticore
+   :name "Manticore"
+   :ac 14
+   :challenge 3
+   :hit-points "8d10 + 24"
+   :abilities {:str 17 :dex 16 :con 17 :int 7 :wis 12 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 11"
+   :size :large
+   :type :monstrosity
+   :speed "30 ft., fly 50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-manticore/tail-spike-regrowth
+           :name "Tail Spike Regrowth"
+           :desc "The manticore has twenty-four tail spikes. Used spikes regrow when the manticore finishes a long rest."})
+        (provide-attr
+          [:attacks :creatures-manticore/multiattack]
+          {:id :creatures-manticore/multiattack
+           :name "Multiattack"
+           :desc "The manticore makes three attacks: one with its bite and two with its claws or three with its tail spikes."})
+        (provide-attr
+          [:attacks :creatures-manticore/bite]
+          {:id :creatures-manticore/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d8+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-manticore/claw]
+          {:id :creatures-manticore/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-manticore/tail-spike]
+          {:id :creatures-manticore/tail-spike
+           :name "Tail Spike"
+           :desc "_Ranged Weapon Attack: _+5 to hit, range 100/200 ft., one target. _Hit: _7 (1d8 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d8+3"
+           :to-hit 5}))}
+  {:id :creatures/medusa
+   :name "Medusa"
+   :ac 15
+   :challenge 6
+   :hit-points "17d8 + 51"
+   :abilities {:str 10 :dex 15 :con 16 :int 12 :wis 13 :cha 15}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :monstrosity
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-medusa/petrifying-gaze
+           :name "Petrifying Gaze"
+           :desc "When a creature that can see the medusa’s eyes starts its turn within 30 feet of the medusa, the medusa can force it to make a DC 14 Constitution saving throw if the medusa isn’t incapacitated and can see the creature. If the saving throw fails by 5 or more, the creature is instantly petrified. Otherwise, a creature that fails the save begins to turn to stone and is restrained. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the _greater restoration _spell or other magic."})
+        (provide-attr
+          [:attacks :creatures-medusa/multiattack]
+          {:id :creatures-medusa/multiattack
+           :name "Multiattack"
+           :desc "The medusa makes either three melee attacks—one with its snake hair and two with its shortsword—or two ranged attacks with its longbow."})
+        (provide-attr
+          [:attacks :creatures-medusa/snake-hair]
+          {:id :creatures-medusa/snake-hair
+           :name "Snake Hair"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one creature. _Hit: _4 (1d4 + 2) piercing damage plus 14 (4d6) poison damage."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-medusa/shortsword]
+          {:id :creatures-medusa/shortsword
+           :name "Shortsword"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-medusa/longbow]
+          {:id :creatures-medusa/longbow
+           :name "Longbow"
+           :desc "_Ranged Weapon Attack: _+5 to hit, range 150/600 ft., one target. _Hit: _6 (1d8 + 2) piercing damage plus 7 (2d6) poison damage."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 5}))}
+  {:id :creatures/dust-mephit
+   :name "Dust Mephit"
+   :ac 12
+   :challenge 0.5
+   :hit-points "5d6"
+   :abilities {:str 5 :dex 14 :con 10 :int 9 :wis 11 :cha 10}
+   :senses "darkvision 60 ft., passive Perception 12"
+   :size :small
+   :type :elemental
+   :speed "30 ft., fly 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-dust-mephit/death-burst
+           :name "Death Burst"
+           :desc "When the mephit dies, it explodes in a burst of dust. Each creature within 5 feet of it must then succeed on a DC 10 Constitution saving throw or be blinded for 1 minute. A blinded creature can repeat the saving throw on each of its turns, ending the effect on itself on a success."})
+        (provide-feature
+          {:id :creatures-dust-mephit/innate-spellcasting
+           :name "Innate Spellcasting (1/Day)"
+           :desc "The mephit can innately cast _sleep,_ requiring no material components. Its innate spellcasting ability is Charisma."})
+        (provide-attr
+          [:attacks :creatures-dust-mephit/claws]
+          {:id :creatures-dust-mephit/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _4 (1d4 + 2) slashing damage."
+           :damage :slashing
+           :dice "1d4+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-dust-mephit/blinding-breath
+           :name "Blinding Breath (Recharge 6)"
+           :desc "The mephit exhales a 15-foot cone of blinding dust. Each creature in that area must succeed on a DC 10 Dexterity saving throw or be blinded for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."}))}
+  {:id :creatures/ice-mephit
+   :name "Ice Mephit"
+   :ac 11
+   :challenge 0.5
+   :hit-points "6d6"
+   :abilities {:str 7 :dex 13 :con 10 :int 9 :wis 11 :cha 12}
+   :senses "darkvision 60 ft., passive Perception 12"
+   :size :small
+   :type :elemental
+   :speed "30 ft., fly 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ice-mephit/death-burst
+           :name "Death Burst"
+           :desc "When the mephit dies, it explodes in a burst of jagged ice. Each creature within 5 feet of it must make a DC 10 Dexterity saving throw, taking 4 (1d8) slashing damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-ice-mephit/false-appearance
+           :name "False Appearance"
+           :desc "While the mephit remains motionless, it is indistinguishable from an ordinary shard of ice."})
+        (provide-feature
+          {:id :creatures-ice-mephit/innate-spellcasting
+           :name "Innate Spellcasting (1/Day)"
+           :desc "The mephit can innately cast _fog cloud,_ requiring no material components. Its innate spellcasting ability is Charisma."})
+        (provide-attr
+          [:attacks :creatures-ice-mephit/claws]
+          {:id :creatures-ice-mephit/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one creature. _Hit: _3 (1d4 + 1) slashing damage plus 2 (1d4) cold damage."
+           :damage :slashing
+           :dice "1d4+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-ice-mephit/frost-breath
+           :name "Frost Breath (Recharge 6)"
+           :desc "The mephit exhales a 15-foot cone of cold air. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 5 (2d4) cold damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/magma-mephit
+   :name "Magma Mephit"
+   :ac 11
+   :challenge 0.5
+   :hit-points "5d6 + 5"
+   :abilities {:str 8 :dex 12 :con 12 :int 7 :wis 10 :cha 10}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :small
+   :type :elemental
+   :speed "30 ft., fly 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-magma-mephit/death-burst
+           :name "Death Burst"
+           :desc "When the mephit dies, it explodes in a burst of lava. Each creature within 5 feet of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one."})
+        (provide-feature
+          {:id :creatures-magma-mephit/false-appearance
+           :name "False Appearance"
+           :desc "While the mephit remains motionless, it is indistinguishable from an ordinary mound of magma."})
+        (provide-feature
+          {:id :creatures-magma-mephit/innate-spellcasting
+           :name "Innate Spellcasting (1/Day)"
+           :desc "The mephit can innately cast _heat metal _(spell save DC 10), requiring no material components. Its innate spellcasting ability is Charisma."})
+        (provide-attr
+          [:attacks :creatures-magma-mephit/claws]
+          {:id :creatures-magma-mephit/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one creature. _Hit: _3 (1d4 + 1) slashing damage plus 2 (1d4) fire damage."
+           :damage :slashing
+           :dice "1d4+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-magma-mephit/fire-breath
+           :name "Fire Breath (Recharge 6)"
+           :desc "The mephit exhales a 15-foot cone of fire. Each creature in that area must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/steam-mephit
+   :name "Steam Mephit"
+   :ac 10
+   :challenge 0.25
+   :hit-points "6d6"
+   :abilities {:str 5 :dex 11 :con 10 :int 11 :wis 10 :cha 12}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :small
+   :type :elemental
+   :speed "30 ft., fly 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-steam-mephit/death-burst
+           :name "Death Burst"
+           :desc "When the mephit dies, it explodes in a cloud of steam. Each creature within 5 feet of the mephit must succeed on a DC 10 Dexterity saving throw or take 4 (1d8) fire damage."})
+        (provide-feature
+          {:id :creatures-steam-mephit/innate-spellcasting
+           :name "Innate Spellcasting (1/Day)"
+           :desc "The mephit can innately cast _blur,_ requiring no material components. Its innate spellcasting ability is Charisma."})
+        (provide-attr
+          [:attacks :creatures-steam-mephit/claws]
+          {:id :creatures-steam-mephit/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one creature. _Hit: _2 (1d4) slashing damage plus 2 (1d4) fire damage."
+           :damage :slashing
+           :dice "1d4"
+           :to-hit 2})
+        (provide-feature
+          {:id :creatures-steam-mephit/steam-breath
+           :name "Steam Breath (Recharge 6)"
+           :desc "The mephit exhales a 15-foot cone of scalding steam. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 4 (1d8) fire damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/merfolk
+   :name "Merfolk"
+   :ac 11
+   :challenge 0.125
+   :hit-points "2d8 + 2"
+   :abilities {:str 10 :dex 13 :con 12 :int 11 :wis 11 :cha 12}
+   :senses "passive Perception 12"
+   :size :medium
+   :type :humanoid
+   :speed "10 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-merfolk/amphibious
+           :name "Amphibious"
+           :desc "The merfolk can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-merfolk/spear]
+          {:id :creatures-merfolk/spear
+           :name "Spear"
+           :desc "_Melee or Ranged Weapon Attack: _+2 to hit, reach 5 ft. or range 20/60 ft., one target. _Hit: _3 (1d6) piercing damage, or 4 (1d8) piercing damage if used with two hands to make a melee attack."
+           :damage :piercing
+           :dice "1d6"
+           :to-hit 2}))}
+  {:id :creatures/merrow
+   :name "Merrow"
+   :ac 13
+   :challenge 2
+   :hit-points "6d10 + 12"
+   :abilities {:str 18 :dex 10 :con 15 :int 8 :wis 10 :cha 9}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :large
+   :type :monstrosity
+   :speed "10 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-merrow/amphibious
+           :name "Amphibious"
+           :desc "The merrow can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-merrow/multiattack]
+          {:id :creatures-merrow/multiattack
+           :name "Multiattack"
+           :desc "The merrow makes two attacks: one with its bite and one with its claws or harpoon."})
+        (provide-attr
+          [:attacks :creatures-merrow/bite]
+          {:id :creatures-merrow/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _8 (1d8 + 4) piercing damage."
+           :damage :piercing
+           :dice "1d8+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-merrow/claws]
+          {:id :creatures-merrow/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _9 (2d4 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d4+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-merrow/harpoon]
+          {:id :creatures-merrow/harpoon
+           :name "Harpoon"
+           :desc "_Melee or Ranged Weapon Attack: _+6 to hit, reach 5 ft. or range 20/60 ft., one target. _Hit: _11 (2d6 + 4) piercing damage. If the target is a Huge or smaller creature, it must succeed on a Strength contest against the merrow or be pulled up to 20 feet toward the merrow."
+           :damage :piercing
+           :dice "2d6+4"
+           :to-hit 6}))}
+  {:id :creatures/mimic
+   :name "Mimic"
+   :ac 12
+   :challenge 2
+   :hit-points "9d8 + 18"
+   :abilities {:str 17 :dex 12 :con 15 :int 5 :wis 13 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 11"
+   :size :medium
+   :type :monstrosity
+   :speed "15 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-mimic/shapechanger
+           :name "Shapechanger"
+           :desc "The mimic can use its action to polymorph into an object or back into its true, amorphous form. Its statistics are the same in each form. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-feature
+          {:id :creatures-mimic/adhesive
+           :name "Adhesive (Object Form Only)"
+           :desc "The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic is also grappled by it (escape DC 13). Ability checks made to escape this grapple have disadvantage."})
+        (provide-feature
+          {:id :creatures-mimic/false-appearance
+           :name "False Appearance (Object Form Only)"
+           :desc "While the mimic remains motionless, it is indistinguishable from an ordinary object."})
+        (provide-feature
+          {:id :creatures-mimic/grappler
+           :name "Grappler"
+           :desc "The mimic has advantage on attack rolls against any creature grappled by it."})
+        (provide-attr
+          [:attacks :creatures-mimic/pseudopod]
+          {:id :creatures-mimic/pseudopod
+           :name "Pseudopod"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) bludgeoning damage. If the mimic is in object form, the target is subjected to its Adhesive trait."
+           :damage :bludgeoning
+           :dice "1d8+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-mimic/bite]
+          {:id :creatures-mimic/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) piercing damage plus 4 (1d8) acid damage."
+           :damage :piercing
+           :dice "1d8+3"
+           :to-hit 5}))}
+  {:id :creatures/minotaur
+   :name "Minotaur"
+   :ac 14
+   :challenge 3
+   :hit-points "9d10 + 27"
+   :abilities {:str 18 :dex 11 :con 16 :int 6 :wis 16 :cha 9}
+   :senses "darkvision 60 ft., passive Perception 17"
+   :size :large
+   :type :monstrosity
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-minotaur/charge
+           :name "Charge"
+           :desc "If the minotaur moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 feet away and knocked prone."})
+        (provide-feature
+          {:id :creatures-minotaur/labyrinthine-recall
+           :name "Labyrinthine Recall"
+           :desc "The minotaur can perfectly recall any path it has traveled."})
+        (provide-feature
+          {:id :creatures-minotaur/reckless
+           :name "Reckless"
+           :desc "At the start of its turn, the minotaur can gain advantage on all melee weapon attack rolls it makes during that turn, but attack rolls against it have advantage until the start of its next turn."})
+        (provide-attr
+          [:attacks :creatures-minotaur/greataxe]
+          {:id :creatures-minotaur/greataxe
+           :name "Greataxe"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _17 (2d12 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d12+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-minotaur/gore]
+          {:id :creatures-minotaur/gore
+           :name "Gore"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d8+4"
+           :to-hit 6}))}
+  {:id :creatures/mummy-lord
+   :name "Mummy Lord"
+   :ac 17
+   :challenge 15
+   :hit-points "13d8 + 39"
+   :abilities {:str 18 :dex 10 :con 17 :int 11 :wis 18 :cha 16}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :medium
+   :type :undead
+   :speed "20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-mummy-lord/magic-resistance
+           :name "Magic Resistance"
+           :desc "The mummy lord has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-mummy-lord/rejuvenation
+           :name "Rejuvenation"
+           :desc "A destroyed mummy lord gains a new body in 24 hours if its heart is intact, regaining all its hit points and becoming active again. The new body appears within 5 feet of the mummy lord’s heart."})
+        (provide-feature
+          {:id :creatures-mummy-lord/spellcasting
+           :name "Spellcasting"
+           :desc "The mummy lord is a 10th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared:"})
+        (provide-attr
+          [:attacks :creatures-mummy-lord/multiattack]
+          {:id :creatures-mummy-lord/multiattack
+           :name "Multiattack"
+           :desc "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."})
+        (provide-attr
+          [:attacks :creatures-mummy-lord/rotting-fist]
+          {:id :creatures-mummy-lord/rotting-fist
+           :name "Rotting Fist"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one target. _Hit: _14 (3d6 + 4) bludgeoning damage plus 21 (6d6) necrotic damage. If the target is a creature, it must succeed on a DC 16 Constitution saving throw or be cursed with mummy rot. The cursed target can’t regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target’s hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the _remove curse _spell or other magic."
+           :damage :bludgeoning
+           :dice "3d6+4"
+           :to-hit 9})
+        (provide-feature
+          {:id :creatures-mummy-lord/dreadful-glare
+           :name "Dreadful Glare"
+           :desc "The mummy lord targets one creature it can see within 60 feet of it. If the target can see the mummy lord, it must succeed on a DC 16 Wisdom saving throw against this magic or become frightened until the end of the mummy’s next turn. If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies and mummy lords for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-mummy-lord/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-mummy-lord/attack
+           :name "Attack"
+           :desc "The mummy lord makes one attack with its rotting fist or uses its Dreadful Glare."})
+        (provide-feature
+          {:id :creatures-mummy-lord/blinding-dust
+           :name "Blinding Dust"
+           :desc "Blinding dust and sand swirls magically around the mummy lord. Each creature within 5 feet of the mummy lord must succeed on a DC 16 Constitution saving throw or be blinded until the end of the creature’s next turn."})
+        (provide-feature
+          {:id :creatures-mummy-lord/blasphemous-word
+           :name "Blasphemous Word (Costs 2 Actions)"
+           :desc "The mummy lord utters a blasphemous word. Each non-undead creature within 10 feet of the mummy lord that can hear the magical utterance must succeed on a DC 16 Constitution saving throw or be stunned until the end of the mummy lord’s next turn."})
+        (provide-feature
+          {:id :creatures-mummy-lord/channel-negative-energy
+           :name "Channel Negative Energy (Costs 2 Actions)"
+           :desc "The mummy lord magically unleashes negative energy. Creatures within 60 feet of the mummy lord, including ones behind barriers and around corners, can’t regain hit points until the end of the mummy lord’s next turn."})
+        (provide-feature
+          {:id :creatures-mummy-lord/whirlwind-of-sand
+           :name "Whirlwind of Sand (Costs 2 Actions)"
+           :desc "The mummy lord magically transforms into a whirlwind of sand, moves up to 60 feet, and reverts to its normal form. While in whirlwind form, the mummy lord is immune to all damage, and it can’t be grappled, petrified, knocked prone, restrained, or stunned. Equipment worn or carried by the mummy lord remain in its possession."}))}
+  {:id :creatures/guardian-naga
+   :name "Guardian Naga"
+   :ac 18
+   :challenge 10
+   :hit-points "15d10 + 45"
+   :abilities {:str 19 :dex 18 :con 16 :int 16 :wis 19 :cha 18}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :large
+   :type :monstrosity
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-guardian-naga/rejuvenation
+           :name "Rejuvenation"
+           :desc "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a _wish _spell can prevent this trait from functioning."})
+        (provide-feature
+          {:id :creatures-guardian-naga/spellcasting
+           :name "Spellcasting"
+           :desc "The naga is an 11th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following cleric spells prepared:"})
+        (provide-attr
+          [:attacks :creatures-guardian-naga/bite]
+          {:id :creatures-guardian-naga/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 10 ft., one creature. _Hit: _8 (1d8 + 4) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :piercing
+           :dice "1d8+4"
+           :to-hit 8})
+        (provide-attr
+          [:attacks :creatures-guardian-naga/spit-poison]
+          {:id :creatures-guardian-naga/spit-poison
+           :name "Spit Poison"
+           :desc "_Ranged Weapon Attack: _+8 to hit, range 15/30 ft., one creature. _Hit: _The target must make a DC 15 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :poison
+           :dice "10d8"
+           :to-hit 8}))}
+  {:id :creatures/spirit-naga
+   :name "Spirit Naga"
+   :ac 15
+   :challenge 8
+   :hit-points "10d10 + 20"
+   :abilities {:str 18 :dex 17 :con 14 :int 16 :wis 15 :cha 16}
+   :senses "darkvision 60 ft., passive Perception 12"
+   :size :large
+   :type :monstrosity
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-spirit-naga/rejuvenation
+           :name "Rejuvenation"
+           :desc "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a _wish _spell can prevent this trait from functioning."})
+        (provide-feature
+          {:id :creatures-spirit-naga/spellcasting
+           :name "Spellcasting"
+           :desc "The naga is a 10th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following wizard spells prepared:"})
+        (provide-attr
+          [:attacks :creatures-spirit-naga/bite]
+          {:id :creatures-spirit-naga/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one creature. _Hit: _7 (1d6 + 4) piercing damage, and the target must make a DC 13 Constitution saving throw, taking 31 (7d8) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :piercing
+           :dice "1d6+4"
+           :to-hit 7}))}
+  {:id :creatures/nightmare
+   :name "Nightmare"
+   :ac 13
+   :challenge 3
+   :hit-points "8d10 + 24"
+   :abilities {:str 18 :dex 15 :con 16 :int 10 :wis 13 :cha 15}
+   :senses "passive Perception 11"
+   :size :large
+   :type :fiend
+   :speed "60 ft., fly 90 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-nightmare/confer-fire-resistance
+           :name "Confer Fire Resistance"
+           :desc "The nightmare can grant resistance to fire damage to anyone riding it."})
+        (provide-feature
+          {:id :creatures-nightmare/illumination
+           :name "Illumination"
+           :desc "The nightmare sheds bright light in a 10-foot radius and dim light for an additional 10 feet."})
+        (provide-attr
+          [:attacks :creatures-nightmare/hooves]
+          {:id :creatures-nightmare/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) bludgeoning damage plus 7 (2d6) fire damage."
+           :damage :bludgeoning
+           :dice "2d8+4"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-nightmare/ethereal-stride
+           :name "Ethereal Stride"
+           :desc "The nightmare and up to three willing creatures within 5 feet of it magically enter the Ethereal Plane from the Material Plane, or vice versa."}))}
+  {:id :creatures/ogre
+   :name "Ogre"
+   :ac 11
+   :challenge 2
+   :hit-points "7d10 + 21"
+   :abilities {:str 19 :dex 8 :con 16 :int 5 :wis 7 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 8"
+   :size :large
+   :type :giant
+   :speed "40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-ogre/greatclub]
+          {:id :creatures-ogre/greatclub
+           :name "Greatclub"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-ogre/javelin]
+          {:id :creatures-ogre/javelin
+           :name "Javelin"
+           :desc "_Melee or Ranged Weapon Attack: _+6 to hit, reach 5 ft. or range 30/120 ft., one target. _Hit: _11 (2d6 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d6+4"
+           :to-hit 6}))}
+  {:id :creatures/oni
+   :name "Oni"
+   :ac 16
+   :challenge 7
+   :hit-points "13d10 + 39"
+   :abilities {:str 19 :dex 11 :con 16 :int 14 :wis 12 :cha 15}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :large
+   :type :giant
+   :speed "30 ft., fly 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-oni/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The oni’s innate spellcasting ability is Charisma (spell save DC 13). The oni can innately cast the following spells, requiring no material components:"})
+        (provide-feature
+          {:id :creatures-oni/magic-weapons
+           :name "Magic Weapons"
+           :desc "The oni’s weapon attacks are magical."})
+        (provide-feature
+          {:id :creatures-oni/regeneration
+           :name "Regeneration"
+           :desc "The oni regains 10 hit points at the start of its turn if it has at least 1 hit point."})
+        (provide-attr
+          [:attacks :creatures-oni/multiattack]
+          {:id :creatures-oni/multiattack
+           :name "Multiattack"
+           :desc "The oni makes two attacks, either with its claws or its glaive."})
+        (provide-attr
+          [:attacks :creatures-oni/claw]
+          {:id :creatures-oni/claw
+           :name "Claw (Oni Form Only)"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _8 (1d8 + 4) slashing damage."
+           :damage :slashing
+           :dice "1d8+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-oni/glaive]
+          {:id :creatures-oni/glaive
+           :name "Glaive"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one target. _Hit: _15 (2d10 + 4) slashing damage, or 9 (1d10 + 4) slashing damage in Small or Medium form."
+           :damage :slashing
+           :dice "2d10+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-oni/change-shape
+           :name "Change Shape"
+           :desc "The oni magically polymorphs into a Small or Medium humanoid, into a Large giant, or back into its true form. Other than its size, its statistics are the same in each form. The only equipment that is transformed is its glaive, which shrinks so that it can be wielded in humanoid form. If the oni dies, it reverts to its true form, and its glaive reverts to its normal size."}))}
+  {:id :creatures/black-pudding
+   :name "Black Pudding"
+   :ac 7
+   :challenge 4
+   :hit-points "10d10 + 30"
+   :abilities {:str 16 :dex 5 :con 16 :int 1 :wis 6 :cha 1}
+   :senses "blindsight 60 ft. (blind beyond this radius), passive Perception 8"
+   :size :large
+   :type :ooze
+   :speed "20 ft., climb 20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-black-pudding/amorphous
+           :name "Amorphous"
+           :desc "The pudding can move through a space as narrow as 1 inch wide without squeezing."})
+        (provide-feature
+          {:id :creatures-black-pudding/corrosive-form
+           :name "Corrosive Form"
+           :desc "A creature that touches the pudding or hits it with a melee attack while within 5 feet of it takes 4 (1d8) acid damage. Any nonmagical weapon made of metal or wood that hits the pudding corrodes. After dealing damage, the weapon takes a permanent and cumulative −1 penalty to damage rolls. If its penalty drops to −5, the weapon is destroyed. Nonmagical ammunition made of metal or wood that hits the pudding is destroyed after dealing damage."})
+        (provide-attr
+          [:attacks :creatures-black-pudding/pseudopod]
+          {:id :creatures-black-pudding/pseudopod
+           :name "Pseudopod"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) bludgeoning damage plus 18 (4d8) acid damage. In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative −1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10."
+           :damage :bludgeoning
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-black-pudding/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-black-pudding/split
+           :name "Split"
+           :desc "When a pudding that is Medium or larger is subjected to lightning or slashing damage, it splits into two new puddings if it has at least 10 hit points. Each new pudding has hit points equal to half the original pudding’s, rounded down. New puddings are one size smaller than the original pudding."}))}
+  {:id :creatures/gelatinous-cube
+   :name "Gelatinous Cube"
+   :ac 6
+   :challenge 2
+   :hit-points "8d10 + 40"
+   :abilities {:str 14 :dex 3 :con 20 :int 1 :wis 6 :cha 1}
+   :senses "blindsight 60 ft. (blind beyond this radius), passive Perception 8"
+   :size :large
+   :type :ooze
+   :speed "15 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gelatinous-cube/ooze-cube
+           :name "Ooze Cube"
+           :desc "The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube’s Engulf and has disadvantage on the saving throw."})
+        (provide-attr
+          [:attacks :creatures-gelatinous-cube/pseudopod]
+          {:id :creatures-gelatinous-cube/pseudopod
+           :name "Pseudopod"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _10 (3d6) acid damage."
+           :damage :acid
+           :dice "3d6"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-gelatinous-cube/engulf
+           :name "Engulf"
+           :desc "The cube moves up to its speed. While doing so, it can enter Large or smaller creatures’ spaces. Whenever the cube enters a creature’s space, the creature must make a DC 12 Dexterity saving throw."}))}
+  {:id :creatures/gray-ooze
+   :name "Gray Ooze"
+   :ac 8
+   :challenge 0.5
+   :hit-points "3d8 + 9"
+   :abilities {:str 12 :dex 6 :con 16 :int 1 :wis 6 :cha 2}
+   :senses "blindsight 60 ft. (blind beyond this radius), passive Perception 8"
+   :size :medium
+   :type :ooze
+   :speed "10 ft., climb 10 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gray-ooze/amorphous
+           :name "Amorphous"
+           :desc "The ooze can move through a space as narrow as 1 inch wide without squeezing."})
+        (provide-feature
+          {:id :creatures-gray-ooze/corrode-metal
+           :name "Corrode Metal"
+           :desc "Any nonmagical weapon made of metal that hits the ooze corrodes. After dealing damage, the weapon takes a permanent and cumulative −1 penalty to damage rolls. If its penalty drops to −5, the weapon is destroyed. Nonmagical ammunition made of metal that hits the ooze is destroyed after dealing damage."})
+        (provide-attr
+          [:attacks :creatures-gray-ooze/pseudopod]
+          {:id :creatures-gray-ooze/pseudopod
+           :name "Pseudopod"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) bludgeoning damage plus 7 (2d6) acid damage, and if the target is wearing nonmagical metal armor, its armor is partly corroded and takes a permanent and cumulative −1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10."
+           :damage :bludgeoning
+           :dice "1d6+1"
+           :to-hit 3}))}
+  {:id :creatures/ochre-jelly
+   :name "Ochre Jelly"
+   :ac 8
+   :challenge 2
+   :hit-points "6d10 + 12"
+   :abilities {:str 15 :dex 6 :con 14 :int 2 :wis 6 :cha 1}
+   :senses "blindsight 60 ft. (blind beyond this radius), passive Perception 8"
+   :size :large
+   :type :ooze
+   :speed "10 ft., climb 10 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ochre-jelly/amorphous
+           :name "Amorphous"
+           :desc "The jelly can move through a space as narrow as 1 inch wide without squeezing."})
+        (provide-feature
+          {:id :creatures-ochre-jelly/spider-climb
+           :name "Spider Climb"
+           :desc "The jelly can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."})
+        (provide-attr
+          [:attacks :creatures-ochre-jelly/pseudopod]
+          {:id :creatures-ochre-jelly/pseudopod
+           :name "Pseudopod"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _9 (2d6 + 2) bludgeoning damage plus 3 (1d6) acid damage."
+           :damage :bludgeoning
+           :dice "2d6+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-ochre-jelly/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-ochre-jelly/split
+           :name "Split"
+           :desc "When a jelly that is Medium or larger is subjected to lightning or slashing damage, it splits into two new jellies if it has at least 10 hit points. Each new jelly has hit points equal to half the original jelly’s, rounded down. New jellies are one size smaller than the original jelly."}))}
+  {:id :creatures/orc
+   :name "Orc"
+   :ac 13
+   :challenge 0.5
+   :hit-points "2d8 + 6"
+   :abilities {:str 16 :dex 12 :con 16 :int 7 :wis 11 :cha 10}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-orc/aggressive
+           :name "Aggressive"
+           :desc "As a bonus action, the orc can move up to its speed toward a hostile creature that it can see."})
+        (provide-attr
+          [:attacks :creatures-orc/greataxe]
+          {:id :creatures-orc/greataxe
+           :name "Greataxe"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _9 (1d12 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d12+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-orc/javelin]
+          {:id :creatures-orc/javelin
+           :name "Javelin"
+           :desc "_Melee or Ranged Weapon Attack: _+5 to hit, reach 5 ft. or range 30/120 ft., one target. _Hit: _6 (1d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d6+3"
+           :to-hit 5}))}
+  {:id :creatures/otyugh
+   :name "Otyugh"
+   :ac 14
+   :challenge 5
+   :hit-points "12d10 + 48"
+   :abilities {:str 16 :dex 11 :con 19 :int 6 :wis 13 :cha 6}
+   :senses "darkvision 120 ft., passive Perception 11"
+   :size :large
+   :type :aberration
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-otyugh/limited-telepathy
+           :name "Limited Telepathy"
+           :desc "The otyugh can magically transmit simple messages and images to any creature within 120 feet of it that can understand a language. This form of telepathy doesn’t allow the receiving creature to telepathically respond."})
+        (provide-attr
+          [:attacks :creatures-otyugh/multiattack]
+          {:id :creatures-otyugh/multiattack
+           :name "Multiattack"
+           :desc "The otyugh makes three attacks: one with its bite and two with its tentacles."})
+        (provide-attr
+          [:attacks :creatures-otyugh/bite]
+          {:id :creatures-otyugh/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _12 (2d8 + 3) piercing damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the target must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target’s hit point maximum lasts until the disease is cured."
+           :damage :piercing
+           :dice "2d8+3"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-otyugh/tentacle]
+          {:id :creatures-otyugh/tentacle
+           :name "Tentacle"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one target. _Hit: _7 (1d8 + 3) bludgeoning damage plus 4 (1d8) piercing damage. If the target is Medium or smaller, it is grappled (escape DC 13) and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target."
+           :damage :bludgeoning
+           :dice "1d8+3"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-otyugh/tentacle-slam
+           :name "Tentacle Slam"
+           :desc "The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must succeed on a DC 14 Constitution saving throw or take 10 (2d6 + 3) bludgeoning damage and be stunned until the end of the otyugh’s next turn. On a successful save, the target takes half the bludgeoning damage and isn’t stunned."}))}
+  {:id :creatures/owlbear
+   :name "Owlbear"
+   :ac 13
+   :challenge 3
+   :hit-points "7d10 + 21"
+   :abilities {:str 20 :dex 12 :con 17 :int 3 :wis 12 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 13"
+   :size :large
+   :type :monstrosity
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-owlbear/keen-sight-and-smell
+           :name "Keen Sight and Smell"
+           :desc "The owlbear has advantage on Wisdom (Perception) checks that rely on sight or smell."})
+        (provide-attr
+          [:attacks :creatures-owlbear/multiattack]
+          {:id :creatures-owlbear/multiattack
+           :name "Multiattack"
+           :desc "The owlbear makes two attacks: one with its beak and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-owlbear/beak]
+          {:id :creatures-owlbear/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one creature. _Hit: _10 (1d10 + 5) piercing damage."
+           :damage :piercing
+           :dice "1d10+5"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-owlbear/claws]
+          {:id :creatures-owlbear/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _14 (2d8 + 5) slashing damage."
+           :damage :slashing
+           :dice "2d8+5"
+           :to-hit 7}))}
+  {:id :creatures/pegasus
+   :name "Pegasus"
+   :ac 12
+   :challenge 2
+   :hit-points "7d10 + 21"
+   :abilities {:str 18 :dex 15 :con 16 :int 10 :wis 15 :cha 13}
+   :senses "passive Perception 16"
+   :size :large
+   :type :celestial
+   :speed "60 ft., fly 90 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-pegasus/hooves]
+          {:id :creatures-pegasus/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d6+4"
+           :to-hit 6}))}
+  {:id :creatures/pseudodragon
+   :name "Pseudodragon"
+   :ac 13
+   :challenge 0.25
+   :hit-points "2d4 + 2"
+   :abilities {:str 6 :dex 15 :con 13 :int 10 :wis 12 :cha 10}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 13"
+   :size :tiny
+   :type :dragon
+   :speed "15 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-pseudodragon/keen-senses
+           :name "Keen Senses"
+           :desc "The pseudodragon has advantage on Wisdom (Perception) checks that rely on sight, hearing, or smell."})
+        (provide-feature
+          {:id :creatures-pseudodragon/magic-resistance
+           :name "Magic Resistance"
+           :desc "The pseudodragon has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-pseudodragon/limited-telepathy
+           :name "Limited Telepathy"
+           :desc "The pseudodragon can magically communicate simple ideas, emotions, and images telepathically with any creature within 100 feet of it that can understand a language."})
+        (provide-attr
+          [:attacks :creatures-pseudodragon/bite]
+          {:id :creatures-pseudodragon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _4 (1d4 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-pseudodragon/sting]
+          {:id :creatures-pseudodragon/sting
+           :name "Sting"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _4 (1d4 + 2) piercing damage, and the target must succeed on a DC 11 Constitution saving throw or become poisoned for 1 hour. If the saving throw fails by 5 or more, the target falls unconscious for the same duration, or until it takes damage or another creature uses an action to shake it awake."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4}))}
+  {:id :creatures/purple-worm
+   :name "Purple Worm"
+   :ac 18
+   :challenge 15
+   :hit-points "15d20 + 90"
+   :abilities {:str 28 :dex 7 :con 22 :int 1 :wis 8 :cha 4}
+   :senses "blindsight 30 ft., tremorsense 60 ft., passive Perception 9"
+   :size :gargantuan
+   :type :monstrosity
+   :speed "50 ft., burrow 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-purple-worm/tunneler-
+           :name "Tunneler."
+           :desc "The worm can burrow through solid rock at half its burrow speed and leaves a 10-foot-diameter tunnel in its wake."})
+        (provide-attr
+          [:attacks :creatures-purple-worm/multiattack]
+          {:id :creatures-purple-worm/multiattack
+           :name "Multiattack"
+           :desc "The worm makes two attacks: one with its bite and one with its stinger."})
+        (provide-attr
+          [:attacks :creatures-purple-worm/bite]
+          {:id :creatures-purple-worm/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 10 ft., one target. _Hit: _22 (3d8 + 9) piercing damage. If the target is a Large or smaller creature, it must succeed on a DC 19 Dexterity saving throw or be swallowed by the worm. A swallowed creature is blinded and restrained, it has total cover against attacks and other effects outside the worm, and it takes 21 (6d6) acid damage at the start of each of the worm’s turns."
+           :damage :piercing
+           :dice "3d8+9"
+           :to-hit 9}))}
+  {:id :creatures/rakshasa
+   :name "Rakshasa"
+   :ac 16
+   :challenge 13
+   :hit-points "13d8 + 52"
+   :abilities {:str 14 :dex 17 :con 18 :int 13 :wis 16 :cha 20}
+   :senses "darkvision 60 ft., passive Perception 13"
+   :size :medium
+   :type :fiend
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-rakshasa/limited-magic-immunity
+           :name "Limited Magic Immunity"
+           :desc "The rakshasa can’t be affected or detected by spells of 6th level or lower unless it wishes to be. It has advantage on saving throws against all other spells and magical effects."})
+        (provide-feature
+          {:id :creatures-rakshasa/innate-spellcasting
+           :name "Innate Spellcasting"
+           :desc "The rakshasa’s innate spellcasting ability is Charisma (spell save DC 18, +10 to hit with spell attacks). The rakshasa can innately cast the following spells, requiring no material components:"})
+        (provide-attr
+          [:attacks :creatures-rakshasa/multiattack]
+          {:id :creatures-rakshasa/multiattack
+           :name "Multiattack"
+           :desc "The rakshasa makes two claw attacks."})
+        (provide-attr
+          [:attacks :creatures-rakshasa/claw]
+          {:id :creatures-rakshasa/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _9 (2d6 + 2) slashing damage, and the target is cursed if it is a creature. The magical curse takes effect whenever the target takes a short or long rest, filling the target’s thoughts with horrible images and dreams. The cursed target gains no benefit from finishing a short or long rest. The curse lasts until it is lifted by a _remove curse _spell or similar magic."
+           :damage :slashing
+           :dice "2d6+2"
+           :to-hit 7}))}
+  {:id :creatures/remorhaz
+   :name "Remorhaz"
+   :ac 17
+   :challenge 11
+   :hit-points "17d12 + 85"
+   :abilities {:str 24 :dex 13 :con 21 :int 4 :wis 10 :cha 5}
+   :senses "darkvision 60 ft., tremorsense 60 ft., passive Perception 10"
+   :size :huge
+   :type :monstrosity
+   :speed "30 ft., burrow 20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-remorhaz/heated-body
+           :name "Heated Body"
+           :desc "A creature that touches the remorhaz or hits it with a melee attack while within 5 feet of it takes 10 (3d6) fire damage."})
+        (provide-attr
+          [:attacks :creatures-remorhaz/bite]
+          {:id :creatures-remorhaz/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+11 to hit, reach 10 ft., one target. _Hit: _40 (6d10 + 7) piercing damage plus 10 (3d6) fire damage. If the target is a creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the remorhaz can’t bite another target."
+           :damage :piercing
+           :dice "6d10+7"
+           :to-hit 11})
+        (provide-feature
+          {:id :creatures-remorhaz/swallow
+           :name "Swallow"
+           :desc "The remorhaz makes one bite attack against a Medium or smaller creature it is grappling. If the attack hits, that creature takes the bite’s damage and is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the remorhaz, and it takes 21 (6d6) acid damage at the start of each of the remorhaz’s turns."}))}
+  {:id :creatures/roc
+   :name "Roc"
+   :ac 15
+   :challenge 11
+   :hit-points "16d20 + 80"
+   :abilities {:str 28 :dex 10 :con 20 :int 3 :wis 10 :cha 9}
+   :senses "passive Perception 14"
+   :size :gargantuan
+   :type :monstrosity
+   :speed "20 ft., fly 120 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-roc/keen-sight
+           :name "Keen Sight"
+           :desc "The roc has advantage on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-roc/multiattack]
+          {:id :creatures-roc/multiattack
+           :name "Multiattack"
+           :desc "The roc makes two attacks: one with its beak and one with its talons."})
+        (provide-attr
+          [:attacks :creatures-roc/beak]
+          {:id :creatures-roc/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 10 ft., one target. _Hit: _27 (4d8 + 9) piercing damage."
+           :damage :piercing
+           :dice "4d8+9"
+           :to-hit 13})
+        (provide-attr
+          [:attacks :creatures-roc/talons]
+          {:id :creatures-roc/talons
+           :name "Talons"
+           :desc "_Melee Weapon Attack: _+13 to hit, reach 5 ft., one target. Hit: 23 (4d6 + 9) slashing damage, and the target is grappled (escape DC 19). Until this grapple ends, the target is restrained, and the roc can’t use its talons on another target."
+           :damage :slashing
+           :dice "4d6+9"
+           :to-hit 13}))}
+  {:id :creatures/roper
+   :name "Roper"
+   :ac 20
+   :challenge 5
+   :hit-points "11d10 + 33"
+   :abilities {:str 18 :dex 8 :con 17 :int 7 :wis 16 :cha 6}
+   :senses "darkvision 60 ft., passive Perception 16"
+   :size :large
+   :type :monstrosity
+   :speed "10 ft., climb 10 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-roper/false-appearance
+           :name "False Appearance"
+           :desc "While the roper remains motionless, it is indistinguishable from a normal cave formation, such as a stalagmite."})
+        (provide-feature
+          {:id :creatures-roper/grasping-tendrils
+           :name "Grasping Tendrils"
+           :desc "The roper can have up to six tendrils at a time. Each tendril can be attacked (AC 20; 10 hit points; immunity to poison and psychic damage). Destroying a tendril deals no damage to the roper, which can extrude a replacement tendril on its next turn. A tendril can also be broken if a creature takes an action and succeeds on a DC 15 Strength check against it."})
+        (provide-feature
+          {:id :creatures-roper/spider-climb
+           :name "Spider Climb"
+           :desc "The roper can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."})
+        (provide-attr
+          [:attacks :creatures-roper/multiattack]
+          {:id :creatures-roper/multiattack
+           :name "Multiattack"
+           :desc "The roper makes four attacks with its tendrils, uses Reel, and makes one attack with its bite."})
+        (provide-attr
+          [:attacks :creatures-roper/bite]
+          {:id :creatures-roper/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _22 (4d8 + 4) piercing damage."
+           :damage :piercing
+           :dice "4d8+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-roper/tendril]
+          {:id :creatures-roper/tendril
+           :name "Tendril"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 50 ft., one creature. _Hit: _The target is grappled (escape DC 15). Until the grapple ends, the target is restrained and has disadvantage on Strength checks and Strength saving throws, and the roper can’t use the same tendril on another target."
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-roper/reel
+           :name "Reel"
+           :desc "The roper pulls each creature grappled by it up to 25 feet straight toward it."}))}
+  {:id :creatures/rust-monster
+   :name "Rust Monster"
+   :ac 14
+   :challenge 0.5
+   :hit-points "5d8 + 5"
+   :abilities {:str 13 :dex 12 :con 13 :int 2 :wis 13 :cha 6}
+   :senses "darkvision 60 ft., passive Perception 11"
+   :size :medium
+   :type :monstrosity
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-rust-monster/iron-scent
+           :name "Iron Scent"
+           :desc "The rust monster can pinpoint, by scent, the location of ferrous metal within 30 feet of it."})
+        (provide-feature
+          {:id :creatures-rust-monster/rust-metal
+           :name "Rust Metal"
+           :desc "Any nonmagical weapon made of metal that hits the rust monster corrodes. After dealing damage, the weapon takes a permanent and cumulative −1 penalty to damage rolls. If its penalty drops to −5, the weapon is destroyed. Nonmagical ammunition made of metal that hits the rust monster is destroyed after dealing damage."})
+        (provide-attr
+          [:attacks :creatures-rust-monster/bite]
+          {:id :creatures-rust-monster/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _5 (1d8 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d8+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-rust-monster/antennae
+           :name "Antennae"
+           :desc "The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn’t being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature can make a DC 11 Dexterity saving throw to avoid the rust monster’s touch."}))}
+  {:id :creatures/sahuagin
+   :name "Sahuagin"
+   :ac 12
+   :challenge 0.5
+   :hit-points "4d8 + 4"
+   :abilities {:str 13 :dex 11 :con 12 :int 12 :wis 13 :cha 9}
+   :senses "darkvision 120 ft., passive Perception 15"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-sahuagin/blood-frenzy
+           :name "Blood Frenzy"
+           :desc "The sahuagin has advantage on melee attack rolls against any creature that doesn’t have all its hit points."})
+        (provide-feature
+          {:id :creatures-sahuagin/limited-amphibiousness
+           :name "Limited Amphibiousness"
+           :desc "The sahuagin can breathe air and water, but it needs to be submerged at least once every 4 hours to avoid suffocating."})
+        (provide-feature
+          {:id :creatures-sahuagin/shark-telepathy
+           :name "Shark Telepathy"
+           :desc "The sahuagin can magically command any shark within 120 feet of it, using a limited telepathy."})
+        (provide-attr
+          [:attacks :creatures-sahuagin/multiattack]
+          {:id :creatures-sahuagin/multiattack
+           :name "Multiattack"
+           :desc "The sahuagin makes two melee attacks: one with its bite and one with its claws or spear."})
+        (provide-attr
+          [:attacks :creatures-sahuagin/bite]
+          {:id :creatures-sahuagin/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _3 (1d4 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d4+1"
+           :to-hit 3})
+        (provide-attr
+          [:attacks :creatures-sahuagin/claws]
+          {:id :creatures-sahuagin/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _3 (1d4 + 1) slashing damage."
+           :damage :slashing
+           :dice "1d4+1"
+           :to-hit 3})
+        (provide-attr
+          [:attacks :creatures-sahuagin/spear]
+          {:id :creatures-sahuagin/spear
+           :name "Spear"
+           :desc "_Melee or Ranged Weapon Attack: _+3 to hit, reach 5 ft. or range 20/60 ft., one target. _Hit: _4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack."
+           :damage :piercing
+           :dice "1d6+1"
+           :to-hit 3}))}
+  {:id :creatures/salamander
+   :name "Salamander"
+   :ac 15
+   :challenge 5
+   :hit-points "12d10 + 24"
+   :abilities {:str 18 :dex 14 :con 15 :int 11 :wis 10 :cha 12}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :large
+   :type :elemental
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-salamander/heated-body
+           :name "Heated Body"
+           :desc "A creature that touches the salamander or hits it with a melee attack while within 5 feet of it takes 7 (2d6) fire damage."})
+        (provide-feature
+          {:id :creatures-salamander/heated-weapons
+           :name "Heated Weapons"
+           :desc "Any metal melee weapon the salamander wields deals an extra 3 (1d6) fire damage on a hit (included in the attack)."})
+        (provide-attr
+          [:attacks :creatures-salamander/multiattack]
+          {:id :creatures-salamander/multiattack
+           :name "Multiattack"
+           :desc "The salamander makes two attacks: one with its spear and one with its tail."})
+        (provide-attr
+          [:attacks :creatures-salamander/spear]
+          {:id :creatures-salamander/spear
+           :name "Spear"
+           :desc "_Melee or Ranged Weapon Attack: _+7 to hit, reach 5 ft. or range 20 ft./60 ft., one target. _Hit: _11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage."
+           :damage :piercing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-salamander/tail]
+          {:id :creatures-salamander/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one target. _Hit: _11 (2d6 + 4) bludgeoning damage plus 7 (2d6) fire damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, the salamander can automatically hit the target with its tail, and the salamander can’t make tail attacks against other targets."
+           :damage :bludgeoning
+           :dice "2d6+4"
+           :to-hit 7}))}
+  {:id :creatures/satyr
+   :name "Satyr"
+   :ac 14
+   :challenge 0.5
+   :hit-points "7d8"
+   :abilities {:str 12 :dex 16 :con 11 :int 12 :wis 10 :cha 14}
+   :senses "passive Perception 12"
+   :size :medium
+   :type :fey
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-satyr/magic-resistance
+           :name "Magic Resistance"
+           :desc "The satyr has advantage on saving throws against spells and other magical effects."})
+        (provide-attr
+          [:attacks :creatures-satyr/ram]
+          {:id :creatures-satyr/ram
+           :name "Ram"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _6 (2d4 + 1) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d4+1"
+           :to-hit 3})
+        (provide-attr
+          [:attacks :creatures-satyr/shortsword]
+          {:id :creatures-satyr/shortsword
+           :name "Shortsword"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-satyr/shortbow]
+          {:id :creatures-satyr/shortbow
+           :name "Shortbow"
+           :desc "_Ranged Weapon Attack: _+5 to hit, range 80/320 ft., one target. _Hit: _6 (1d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d6+3"
+           :to-hit 5}))}
+  {:id :creatures/shadow
+   :name "Shadow"
+   :ac 12
+   :challenge 0.5
+   :hit-points "3d8 + 3"
+   :abilities {:str 6 :dex 14 :con 13 :int 6 :wis 10 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :undead
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-shadow/amorphous
+           :name "Amorphous"
+           :desc "The shadow can move through a space as narrow as 1 inch wide without squeezing."})
+        (provide-feature
+          {:id :creatures-shadow/shadow-stealth
+           :name "Shadow Stealth"
+           :desc "While in dim light or darkness, the shadow can take the Hide action as a bonus action."})
+        (provide-feature
+          {:id :creatures-shadow/sunlight-weakness
+           :name "Sunlight Weakness"
+           :desc "While in sunlight, the shadow has disadvantage on attack rolls, ability checks, and saving throws."})
+        (provide-attr
+          [:attacks :creatures-shadow/strength-drain]
+          {:id :creatures-shadow/strength-drain
+           :name "Strength Drain"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _9 (2d6 + 2) necrotic damage, and the target’s Strength score is reduced by 1d4. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest."
+           :damage :necrotic
+           :dice "2d6+2"
+           :to-hit 4}))}
+  {:id :creatures/shambling-mound
+   :name "Shambling Mound"
+   :ac 15
+   :challenge 5
+   :hit-points "16d10 + 48"
+   :abilities {:str 18 :dex 8 :con 16 :int 5 :wis 10 :cha 5}
+   :senses "blindsight 60 ft. (blind beyond this radius), passive Perception 10"
+   :size :large
+   :type :plant
+   :speed "20 ft., swim 20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-shambling-mound/lightning-absorption-
+           :name "Lightning Absorption."
+           :desc "Whenever the shambling mound is subjected to lightning damage, it takes no damage and regains a number of hit points equal to the lightning damage dealt."})
+        (provide-attr
+          [:attacks :creatures-shambling-mound/multiattack]
+          {:id :creatures-shambling-mound/multiattack
+           :name "Multiattack"
+           :desc "The shambling mound makes two slam attacks. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it."})
+        (provide-attr
+          [:attacks :creatures-shambling-mound/slam]
+          {:id :creatures-shambling-mound/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-shambling-mound/engulf
+           :name "Engulf"
+           :desc "The shambling mound engulfs a Medium or smaller creature grappled by it. The engulfed target is blinded, restrained, and unable to breathe, and it must succeed on a DC 14 Constitution saving throw at the start of each of the mound’s turns or take 13 (2d8 + 4) bludgeoning damage. If the mound moves, the engulfed target moves with it. The"}))}
+  {:id :creatures/shield-guardian
+   :name "Shield Guardian"
+   :ac 17
+   :challenge 7
+   :hit-points "15d10 + 60"
+   :abilities {:str 18 :dex 8 :con 18 :int 7 :wis 10 :cha 3}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 10"
+   :size :large
+   :type :construct
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-shield-guardian/bound
+           :name "Bound"
+           :desc "The shield guardian is magically bound to an amulet. As long as the guardian and its amulet are on the same plane of existence, the amulet’s wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. If the guardian is within 60 feet of the amulet’s wearer, half of any damage the wearer takes (rounded up) is transferred to the guardian."})
+        (provide-feature
+          {:id :creatures-shield-guardian/regeneration
+           :name "Regeneration"
+           :desc "The shield guardian regains 10 hit points at the start of its turn if it has at least 1 hit point."})
+        (provide-feature
+          {:id :creatures-shield-guardian/spell-storing-
+           :name "Spell Storing."
+           :desc "A spellcaster who wears the shield guardian’s amulet can cause the guardian to store one spell of 4th level or lower. To do so, the wearer must cast the spell on the guardian. The spell has no effect but is stored within the guardian. When commanded to do so by the wearer or when a situation arises that was predefined by the spellcaster, the guardian casts the stored spell with any parameters set by the original caster, requiring no components. When the spell is cast or a new spell is stored, any previously stored spell is lost."})
+        (provide-attr
+          [:attacks :creatures-shield-guardian/multiattack]
+          {:id :creatures-shield-guardian/multiattack
+           :name "Multiattack"
+           :desc "The guardian makes two fist attacks."})
+        (provide-attr
+          [:attacks :creatures-shield-guardian/fist]
+          {:id :creatures-shield-guardian/fist
+           :name "Fist"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-shield-guardian/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-shield-guardian/shield
+           :name "Shield"
+           :desc "When a creature makes an attack against the wearer of the guardian’s amulet, the guardian grants a +2 bonus to the wearer’s AC if the guardian is within 5 feet of the wearer."}))}
+  {:id :creatures/skeleton
+   :name "Skeleton"
+   :ac 13
+   :challenge 0.25
+   :hit-points "2d8 + 4"
+   :abilities {:str 10 :dex 14 :con 15 :int 6 :wis 8 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 9"
+   :size :medium
+   :type :undead
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-skeleton/shortsword]
+          {:id :creatures-skeleton/shortsword
+           :name "Shortsword"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-skeleton/shortbow]
+          {:id :creatures-skeleton/shortbow
+           :name "Shortbow"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 80/320 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/minotaur-skeleton
+   :name "Minotaur Skeleton"
+   :ac 12
+   :challenge 2
+   :hit-points "9d10 + 18"
+   :abilities {:str 18 :dex 11 :con 15 :int 6 :wis 8 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 9"
+   :size :large
+   :type :undead
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-minotaur-skeleton/charge
+           :name "Charge"
+           :desc "If the skeleton moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 feet away and knocked prone."})
+        (provide-attr
+          [:attacks :creatures-minotaur-skeleton/greataxe]
+          {:id :creatures-minotaur-skeleton/greataxe
+           :name "Greataxe"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _17 (2d12 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d12+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-minotaur-skeleton/gore]
+          {:id :creatures-minotaur-skeleton/gore
+           :name "Gore"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d8+4"
+           :to-hit 6}))}
+  {:id :creatures/warhorse-skeleton
+   :name "Warhorse Skeleton"
+   :ac 13
+   :challenge 0.5
+   :hit-points "3d10 + 6"
+   :abilities {:str 18 :dex 12 :con 15 :int 2 :wis 8 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 9"
+   :size :large
+   :type :undead
+   :speed "60 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-warhorse-skeleton/hooves]
+          {:id :creatures-warhorse-skeleton/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d6+4"
+           :to-hit 6}))}
+  {:id :creatures/specter
+   :name "Specter"
+   :ac 12
+   :challenge 1
+   :hit-points "5d8"
+   :abilities {:str 1 :dex 14 :con 11 :int 10 :wis 10 :cha 11}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :medium
+   :type :undead
+   :speed "0 ft., fly 50 ft. (hover)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-specter/incorporeal-movement
+           :name "Incorporeal Movement"
+           :desc "The specter can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."})
+        (provide-feature
+          {:id :creatures-specter/sunlight-sensitivity
+           :name "Sunlight Sensitivity"
+           :desc "While in sunlight, the specter has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-specter/life-drain]
+          {:id :creatures-specter/life-drain
+           :name "Life Drain"
+           :desc "_Melee Spell Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _10 (3d6) necrotic damage. The target must succeed on a DC 10 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the creature finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+           :damage :necrotic
+           :dice "3d6"
+           :to-hit 4}))}
+  {:id :creatures/androsphinx
+   :name "Androsphinx"
+   :ac 17
+   :challenge 17
+   :hit-points "19d10 + 95"
+   :abilities {:str 22 :dex 10 :con 20 :int 16 :wis 18 :cha 23}
+   :senses "truesight 120 ft., passive Perception 20"
+   :size :large
+   :type :monstrosity
+   :speed "40 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-androsphinx/inscrutable
+           :name "Inscrutable"
+           :desc "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx’s intentions or sincerity have disadvantage."})
+        (provide-feature
+          {:id :creatures-androsphinx/magic-weapons
+           :name "Magic Weapons"
+           :desc "The sphinx’s weapon attacks are magical."})
+        (provide-feature
+          {:id :creatures-androsphinx/spellcasting
+           :name "Spellcasting"
+           :desc "The sphinx is a 12th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following cleric spells prepared:"})
+        (provide-attr
+          [:attacks :creatures-androsphinx/multiattack]
+          {:id :creatures-androsphinx/multiattack
+           :name "Multiattack"
+           :desc "The sphinx makes two claw attacks."})
+        (provide-attr
+          [:attacks :creatures-androsphinx/claw]
+          {:id :creatures-androsphinx/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+12 to hit, reach 5 ft., one target. _Hit: _17 (2d10 + 6) slashing damage."
+           :damage :slashing
+           :dice "2d10+6"
+           :to-hit 12})
+        (provide-feature
+          {:id :creatures-androsphinx/roar
+           :name "Roar (3/Day)"
+           :desc "The sphinx emits a magical roar. Each time it roars before finishing a long rest, the roar is louder and the effect is different, as detailed below. Each creature within 500 feet of the sphinx and able to hear the roar must make a saving throw."})
+        (provide-feature
+          {:id :creatures-androsphinx/first-roar
+           :name "First Roar"
+           :desc "Each creature that fails a DC 18 Wisdom saving throw is frightened for 1 minute. A frightened creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."})
+        (provide-feature
+          {:id :creatures-androsphinx/second-roar
+           :name "Second Roar"
+           :desc "Each creature that fails a DC 18 Wisdom saving throw is deafened and frightened for 1 minute. A frightened creature is paralyzed and can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."})
+        (provide-feature
+          {:id :creatures-androsphinx/third-roar
+           :name "Third Roar"
+           :desc "Each creature makes a DC 18 Constitution saving throw. On a failed save, a creature takes 44 (8d10) thunder damage and is knocked prone. On a successful save, the creature takes half as much damage and isn’t knocked prone."})
+        (provide-feature
+          {:id :creatures-androsphinx/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-androsphinx/claw-attack
+           :name "Claw Attack"
+           :desc "The sphinx makes one claw attack."})
+        (provide-feature
+          {:id :creatures-androsphinx/teleport
+           :name "Teleport (Costs 2 Actions)"
+           :desc "The sphinx magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."})
+        (provide-feature
+          {:id :creatures-androsphinx/cast-a-spell
+           :name "Cast a Spell (Costs 3 Actions)"
+           :desc "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."}))}
+  {:id :creatures/gynosphinx
+   :name "Gynosphinx"
+   :ac 17
+   :challenge 11
+   :hit-points "16d10 + 48"
+   :abilities {:str 18 :dex 15 :con 16 :int 18 :wis 18 :cha 18}
+   :senses "truesight 120 ft., passive Perception 18"
+   :size :large
+   :type :monstrosity
+   :speed "40 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gynosphinx/inscrutable
+           :name "Inscrutable"
+           :desc "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx’s intentions or sincerity have disadvantage."})
+        (provide-feature
+          {:id :creatures-gynosphinx/magic-weapons
+           :name "Magic Weapons"
+           :desc "The sphinx’s weapon attacks are magical."})
+        (provide-feature
+          {:id :creatures-gynosphinx/spellcasting
+           :name "Spellcasting"
+           :desc "The sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:"})
+        (provide-attr
+          [:attacks :creatures-gynosphinx/multiattack]
+          {:id :creatures-gynosphinx/multiattack
+           :name "Multiattack"
+           :desc "The sphinx makes two claw attacks."})
+        (provide-attr
+          [:attacks :creatures-gynosphinx/claw]
+          {:id :creatures-gynosphinx/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d8+4"
+           :to-hit 8})
+        (provide-feature
+          {:id :creatures-gynosphinx/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-gynosphinx/claw-attack
+           :name "Claw Attack"
+           :desc "The sphinx makes one claw attack."})
+        (provide-feature
+          {:id :creatures-gynosphinx/teleport
+           :name "Teleport (Costs 2 Actions)"
+           :desc "The sphinx magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."})
+        (provide-feature
+          {:id :creatures-gynosphinx/cast-a-spell
+           :name "Cast a Spell (Costs 3 Actions)"
+           :desc "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."}))}
+  {:id :creatures/sprite
+   :name "Sprite"
+   :ac 15
+   :challenge 0.25
+   :hit-points "1d4"
+   :abilities {:str 3 :dex 18 :con 10 :int 14 :wis 13 :cha 11}
+   :senses "passive Perception 13"
+   :size :tiny
+   :type :fey
+   :speed "10 ft., fly 40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-sprite/longsword]
+          {:id :creatures-sprite/longsword
+           :name "Longsword"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _1 slashing damage."
+           :to-hit 2})
+        (provide-attr
+          [:attacks :creatures-sprite/shortbow]
+          {:id :creatures-sprite/shortbow
+           :name "Shortbow"
+           :desc "_Ranged Weapon Attack: _+6 to hit, range 40/160 ft., one target. _Hit: _1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or become poisoned for 1 minute. If its saving throw result is 5 or lower, the poisoned target falls unconscious for the same duration, or until it takes damage or another creature takes an action to shake it awake."
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-sprite/heart-sight
+           :name "Heart Sight"
+           :desc "The sprite touches a creature and magically knows the creature’s current emotional state. If the target fails a DC 10 Charisma saving throw, the sprite also knows the creature’s alignment. Celestials, fiends, and undead automatically fail the saving throw."})
+        (provide-feature
+          {:id :creatures-sprite/invisibility
+           :name "Invisibility"
+           :desc "The sprite magically turns invisible until it attacks or casts a spell, or until its concentration ends (as if concentrating on a spell). Any equipment the sprite wears or carries is invisible with it."}))}
+  {:id :creatures/stirge
+   :name "Stirge"
+   :ac 14
+   :challenge 0.125
+   :hit-points "1d4"
+   :abilities {:str 4 :dex 16 :con 11 :int 2 :wis 8 :cha 6}
+   :senses "darkvision 60 ft., passive Perception 9"
+   :size :tiny
+   :type :beast
+   :speed "10 ft., fly 40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-stirge/blood-drain]
+          {:id :creatures-stirge/blood-drain
+           :name "Blood Drain"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one creature. _Hit: _5 (1d4 + 3) piercing damage, and the stirge attaches to the target. While attached, the stirge doesn’t attack. Instead, at the start of each of the stirge’s turns, the target loses 5 (1d4 + 3) hit points due to blood loss."
+           :damage :piercing
+           :dice "1d4+3"
+           :to-hit 5}))}
+  {:id :creatures/succubus-incubus
+   :name "Succubus/Incubus"
+   :ac 15
+   :challenge 4
+   :hit-points "12d8 + 12"
+   :abilities {:str 8 :dex 17 :con 13 :int 15 :wis 12 :cha 20}
+   :senses "darkvision 60 ft., passive Perception 15"
+   :size :medium
+   :type :fiend
+   :speed "30 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-succubus-incubus/telepathic-bond
+           :name "Telepathic Bond"
+           :desc "The fiend ignores the range restriction on its telepathy when communicating with a creature it has charmed. The two don’t even need to be on the same plane of existence."})
+        (provide-feature
+          {:id :creatures-succubus-incubus/shapechanger
+           :name "Shapechanger"
+           :desc "The fiend can use its action to polymorph into a Small or Medium humanoid, or back into its true form. Without wings, the fiend loses its flying speed. Other than its size and speed, its statistics are the same in each form. Any equipment it is wearing or carrying isn’t transformed. It reverts to its true form if it dies."})
+        (provide-attr
+          [:attacks :creatures-succubus-incubus/claw]
+          {:id :creatures-succubus-incubus/claw
+           :name "Claw (Fiend Form Only)"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-succubus-incubus/charm
+           :name "Charm"
+           :desc "One humanoid the fiend can see within 30 feet of it must succeed on a DC 15 Wisdom saving throw or be magically charmed for 1 day. The charmed target obeys the fiend’s verbal or telepathic commands. If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend’s Charm for the next 24 hours."}))}
+  {:id :creatures/tarrasque
+   :name "Tarrasque"
+   :ac 25
+   :challenge 30
+   :hit-points "33d20 + 330"
+   :abilities {:str 30 :dex 11 :con 30 :int 3 :wis 11 :cha 11}
+   :senses "blindsight 120 ft., passive Perception 10"
+   :size :gargantuan
+   :type :monstrosity
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-tarrasque/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the tarrasque fails a saving throw, it can choose to succeed instead."})
+        (provide-feature
+          {:id :creatures-tarrasque/magic-resistance
+           :name "Magic Resistance"
+           :desc "The tarrasque has advantage on saving throws against spells and other magical effects."})
+        (provide-feature
+          {:id :creatures-tarrasque/reflective-carapace
+           :name "Reflective Carapace"
+           :desc "Any time the tarrasque is targeted by a _magic missile _spell, a line spell, or a spell that requires a ranged attack roll, roll a d6. On a 1 to 5, the tarrasque is unaffected. On a 6, the tarrasque is unaffected, and the effect is reflected back at the caster as though it originated from the tarrasque, turning the caster into the target."})
+        (provide-feature
+          {:id :creatures-tarrasque/siege-monster
+           :name "Siege Monster"
+           :desc "The tarrasque deals double damage to objects and structures."})
+        (provide-attr
+          [:attacks :creatures-tarrasque/multiattack]
+          {:id :creatures-tarrasque/multiattack
+           :name "Multiattack"
+           :desc "The tarrasque can use its Frightful Presence. It then makes five attacks: one with its bite, two with its claws, one with its horns, and one with its tail. It can use its Swallow instead of its bite."})
+        (provide-attr
+          [:attacks :creatures-tarrasque/bite]
+          {:id :creatures-tarrasque/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+19 to hit, reach 10 ft., one target. _Hit: _36 (4d12 + 10) piercing damage. If the target is a creature, it is grappled (escape DC 20). Until this grapple ends, the target is restrained, and the tarrasque can’t bite another target."
+           :damage :piercing
+           :dice "4d12+10"
+           :to-hit 19})
+        (provide-attr
+          [:attacks :creatures-tarrasque/claw]
+          {:id :creatures-tarrasque/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+19 to hit, reach 15 ft., one target. _Hit: _28 (4d8 + 10) slashing damage."
+           :damage :slashing
+           :dice "4d8+10"
+           :to-hit 19})
+        (provide-attr
+          [:attacks :creatures-tarrasque/horns]
+          {:id :creatures-tarrasque/horns
+           :name "Horns"
+           :desc "_Melee Weapon Attack: _+19 to hit, reach 10 ft., one target. _Hit: _32 (4d10 + 10) piercing damage."
+           :damage :piercing
+           :dice "4d10+10"
+           :to-hit 19})
+        (provide-attr
+          [:attacks :creatures-tarrasque/tail]
+          {:id :creatures-tarrasque/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+19 to hit, reach 20 ft., one target. _Hit: _24 (4d6 + 10) bludgeoning damage. If the target is a creature, it must succeed on a DC 20 Strength saving throw or be knocked prone."
+           :damage :bludgeoning
+           :dice "4d6+10"
+           :to-hit 19})
+        (provide-feature
+          {:id :creatures-tarrasque/frightful-presence
+           :name "Frightful Presence"
+           :desc "Each creature of the tarrasque’s choice within 120 feet of it and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, with disadvantage if the tarrasque is within line of sight, ending the effect on itself on a success. If a creature’s saving throw is successful or the effect ends for it, the creature is immune to the tarrasque’s Frightful Presence for the next 24 hours."})
+        (provide-feature
+          {:id :creatures-tarrasque/swallow
+           :name "Swallow"
+           :desc "The tarrasque makes one bite attack against a Large or smaller creature it is grappling. If the attack hits, the target takes the bite’s damage, the target is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the tarrasque, and it takes 56 (16d6) acid damage at the start of each of the tarrasque’s turns."})
+        (provide-feature
+          {:id :creatures-tarrasque/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-tarrasque/attack
+           :name "Attack"
+           :desc "The tarrasque makes one claw attack or tail attack."})
+        (provide-feature
+          {:id :creatures-tarrasque/move
+           :name "Move"
+           :desc "The tarrasque moves up to half its speed."})
+        (provide-feature
+          {:id :creatures-tarrasque/chomp
+           :name "Chomp (Costs 2 Actions)"
+           :desc "The tarrasque makes one bite attack or uses its Swallow."}))}
+  {:id :creatures/treant
+   :name "Treant"
+   :ac 16
+   :challenge 9
+   :hit-points "12d12 + 60"
+   :abilities {:str 23 :dex 8 :con 21 :int 12 :wis 16 :cha 12}
+   :senses "passive Perception 13"
+   :size :huge
+   :type :plant
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-treant/false-appearance
+           :name "False Appearance"
+           :desc "While the treant remains motionless, it is indistinguishable from a normal tree."})
+        (provide-feature
+          {:id :creatures-treant/siege-monster
+           :name "Siege Monster"
+           :desc "The treant deals double damage to objects and structures."})
+        (provide-attr
+          [:attacks :creatures-treant/multiattack]
+          {:id :creatures-treant/multiattack
+           :name "Multiattack"
+           :desc "The treant makes two slam attacks."})
+        (provide-attr
+          [:attacks :creatures-treant/slam]
+          {:id :creatures-treant/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one target. _Hit: _16 (3d6 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d6+6"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-treant/rock]
+          {:id :creatures-treant/rock
+           :name "Rock"
+           :desc "_Ranged Weapon Attack: _+10 to hit, range 60/180 ft., one target. _Hit: _28 (4d10 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "4d10+6"
+           :to-hit 10})
+        (provide-feature
+          {:id :creatures-treant/animate-trees
+           :name "Animate Trees (1/Day)"
+           :desc "The treant magically animates one or two trees it can see within 60 feet of it. These trees have the same statistics as a treant, except they have Intelligence and Charisma scores of 1, they can’t speak, and they have only the Slam action option. An animated tree acts as an ally of the treant. The tree remains animate for 1 day or until it dies; until the treant dies or is more than 120 feet from the tree; or until the treant takes a bonus action to turn it back into an inanimate tree. The tree then takes root if possible."}))}
+  {:id :creatures/troll
+   :name "Troll"
+   :ac 15
+   :challenge 5
+   :hit-points "8d10 + 40"
+   :abilities {:str 18 :dex 13 :con 20 :int 7 :wis 9 :cha 7}
+   :senses "darkvision 60 ft., passive Perception 12"
+   :size :large
+   :type :giant
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-troll/keen-smell
+           :name "Keen Smell"
+           :desc "The troll has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-feature
+          {:id :creatures-troll/regeneration
+           :name "Regeneration"
+           :desc "The troll regains 10 hit points at the start of its turn. If the troll takes acid or fire damage, this trait doesn’t function at the start of the troll’s next turn. The troll dies only if it starts its turn with 0 hit points and doesn’t regenerate."})
+        (provide-attr
+          [:attacks :creatures-troll/multiattack]
+          {:id :creatures-troll/multiattack
+           :name "Multiattack"
+           :desc "The troll makes three attacks: one with its bite and two with its claws."})
+        (provide-attr
+          [:attacks :creatures-troll/bite]
+          {:id :creatures-troll/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _7 (1d6 + 4) piercing damage."
+           :damage :piercing
+           :dice "1d6+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-troll/claw]
+          {:id :creatures-troll/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 7}))}
+  {:id :creatures/vampire
+   :name "Vampire"
+   :ac 16
+   :challenge 13
+   :hit-points "17d8 + 68"
+   :abilities {:str 18 :dex 18 :con 18 :int 17 :wis 15 :cha 18}
+   :senses "darkvision 120 ft., passive Perception 17"
+   :size :medium
+   :type :undead
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-vampire/shapechanger
+           :name "Shapechanger"
+           :desc "If the vampire isn’t in sunlight or running water, it can use its action to polymorph into a Tiny bat or a Medium cloud of mist, or back into its true form."})
+        (provide-feature
+          {:id :creatures-vampire/legendary-resistance
+           :name "Legendary Resistance (3/Day)"
+           :desc "If the vampire fails a saving throw, it can choose to succeed instead."})
+        (provide-feature
+          {:id :creatures-vampire/misty-escape
+           :name "Misty Escape"
+           :desc "When it drops to 0 hit points outside its resting place, the vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious, provided that it isn’t in sunlight or running water. If it can’t transform, it is destroyed."})
+        (provide-feature
+          {:id :creatures-vampire/multiattack
+           :name "Multiattack (Vampire Form Only)"
+           :desc "The vampire makes two attacks, only one of which can be a bite attack."})
+        (provide-attr
+          [:attacks :creatures-vampire/unarmed-strike]
+          {:id :creatures-vampire/unarmed-strike
+           :name "Unarmed Strike (Vampire Form Only)"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one creature. _Hit: _8 (1d8 + 4) bludgeoning damage. Instead of dealing damage, the vampire can grapple the target (escape DC 18)."
+           :damage :bludgeoning
+           :dice "1d8+4"
+           :to-hit 9})
+        (provide-attr
+          [:attacks :creatures-vampire/bite]
+          {:id :creatures-vampire/bite
+           :name "Bite (Bat or Vampire Form Only)"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. _Hit:_"
+           :to-hit 9})
+        (provide-feature
+          {:id :creatures-vampire/legendary-actions
+           :name "Legendary Actions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-vampire/move
+           :name "Move"
+           :desc "The vampire moves up to its speed without provoking opportunity attacks."})
+        (provide-feature
+          {:id :creatures-vampire/unarmed-strike
+           :name "Unarmed Strike"
+           :desc "The vampire makes one unarmed strike."})
+        (provide-feature
+          {:id :creatures-vampire/bite
+           :name "Bite (Costs 2 Actions)"
+           :desc "The vampire makes one bite attack."}))}
+  {:id :creatures/vampire-spawn
+   :name "Vampire Spawn"
+   :ac 15
+   :challenge 5
+   :hit-points "11d8 + 33"
+   :abilities {:str 16 :dex 16 :con 16 :int 11 :wis 10 :cha 12}
+   :senses "darkvision 60 ft., passive Perception 13"
+   :size :medium
+   :type :undead
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-vampire-spawn/regeneration
+           :name "Regeneration"
+           :desc "The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn’t in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn’t function at the start of the vampire’s next turn."})
+        (provide-feature
+          {:id :creatures-vampire-spawn/spider-climb
+           :name "Spider Climb"
+           :desc "The vampire can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."})
+        (provide-feature
+          {:id :creatures-vampire-spawn/vampire-weaknesses
+           :name "Vampire Weaknesses"
+           :desc "The vampire has the following flaws:"})
+        (provide-attr
+          [:attacks :creatures-vampire-spawn/multiattack]
+          {:id :creatures-vampire-spawn/multiattack
+           :name "Multiattack"
+           :desc "The vampire makes two attacks, only one of which can be a bite attack."})
+        (provide-attr
+          [:attacks :creatures-vampire-spawn/claws]
+          {:id :creatures-vampire-spawn/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one creature. _Hit: _8 (2d4 + 3) slashing damage. Instead of dealing damage, the vampire can grapple the target (escape DC 13)."
+           :damage :slashing
+           :dice "2d4+3"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-vampire-spawn/bite]
+          {:id :creatures-vampire-spawn/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. _Hit: _6 (1d6 + 3) piercing damage plus 7 (2d6) necrotic damage. The target’s hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+           :damage :piercing
+           :dice "1d6+3"
+           :to-hit 6}))}
+  {:id :creatures/wight
+   :name "Wight"
+   :ac 14
+   :challenge 3
+   :hit-points "6d8 + 18"
+   :abilities {:str 15 :dex 14 :con 16 :int 10 :wis 13 :cha 15}
+   :senses "darkvision 60 ft., passive Perception 13"
+   :size :medium
+   :type :undead
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-wight/sunlight-sensitivity
+           :name "Sunlight Sensitivity"
+           :desc "While in sunlight, the wight has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-wight/multiattack]
+          {:id :creatures-wight/multiattack
+           :name "Multiattack"
+           :desc "The wight makes two longsword attacks or two longbow attacks. It can use its Life Drain in place of one longsword attack."})
+        (provide-attr
+          [:attacks :creatures-wight/life-drain]
+          {:id :creatures-wight/life-drain
+           :name "Life Drain"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _5 (1d6 + 2) necrotic damage. The target must succeed on a DC 13 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+           :damage :necrotic
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/will-o-wisp
+   :name "Will-o’-Wisp"
+   :ac 19
+   :challenge 2
+   :hit-points "9d4"
+   :abilities {:str 1 :dex 28 :con 10 :int 13 :wis 14 :cha 11}
+   :senses "darkvision 120 ft., passive Perception 12"
+   :size :tiny
+   :type :undead
+   :speed "0 ft., fly 50 ft. (hover)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-will-o-wisp/consume-life
+           :name "Consume Life"
+           :desc "As a bonus action, the will-o’-wisp can target one creature it can see within 5 feet of it that has 0 hit points and is still alive. The target must succeed on a DC 10 Constitution saving throw against this magic or die. If the target dies, the will-o’-wisp regains 10 (3d6) hit points."})
+        (provide-feature
+          {:id :creatures-will-o-wisp/ephemeral
+           :name "Ephemeral"
+           :desc "The will-o’-wisp can’t wear or carry anything."})
+        (provide-feature
+          {:id :creatures-will-o-wisp/incorporeal-movement
+           :name "Incorporeal Movement"
+           :desc "The will-o’-wisp can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."})
+        (provide-feature
+          {:id :creatures-will-o-wisp/variable-illumination
+           :name "Variable Illumination"
+           :desc "The will-o’-wisp sheds bright light in a 5- to 20-foot radius and dim light for an additional number of feet equal to the chosen radius. The will-o’-wisp can alter the radius as a bonus action."})
+        (provide-attr
+          [:attacks :creatures-will-o-wisp/shock]
+          {:id :creatures-will-o-wisp/shock
+           :name "Shock"
+           :desc "_Melee Spell Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _9 (2d8) lightning damage."
+           :damage :lightning
+           :dice "2d8"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-will-o-wisp/invisibility
+           :name "Invisibility"
+           :desc "The will-o’-wisp and its light magically become invisible until it attacks or uses its Consume Life, or until its concentration ends (as if concentrating on a spell)."}))}
+  {:id :creatures/wraith
+   :name "Wraith"
+   :ac 13
+   :challenge 5
+   :hit-points "9d8 + 27"
+   :abilities {:str 6 :dex 16 :con 16 :int 12 :wis 14 :cha 15}
+   :senses "darkvision 60 ft., passive Perception 12"
+   :size :medium
+   :type :undead
+   :speed "0 ft., fly 60 ft. (hover)"
+   :! (on-state
+        (provide-feature
+          {:id :creatures-wraith/incorporeal-movement
+           :name "Incorporeal Movement"
+           :desc "The wraith can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."})
+        (provide-feature
+          {:id :creatures-wraith/sunlight-sensitivity
+           :name "Sunlight Sensitivity"
+           :desc "While in sunlight, the wraith has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-wraith/life-drain]
+          {:id :creatures-wraith/life-drain
+           :name "Life Drain"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one creature. _Hit: _21 (4d8 + 3) necrotic damage. The target must succeed on a DC 14 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+           :damage :necrotic
+           :dice "4d8+3"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-wraith/create-specter
+           :name "Create Specter"
+           :desc "The wraith targets a humanoid within 10 feet of it that has been dead for no longer than 1 minute and died violently. The target’s spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith’s control. The wraith can have no more than seven specters under its control at one time."}))}
+  {:id :creatures/wyvern
+   :name "Wyvern"
+   :ac 13
+   :challenge 6
+   :hit-points "13d10 + 39"
+   :abilities {:str 19 :dex 10 :con 16 :int 5 :wis 12 :cha 6}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :large
+   :type :dragon
+   :speed "20 ft., fly 80 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-wyvern/multiattack]
+          {:id :creatures-wyvern/multiattack
+           :name "Multiattack"
+           :desc "The wyvern makes two attacks: one with its bite and one with its stinger. While flying, it can use its claws in place of one other attack."})
+        (provide-attr
+          [:attacks :creatures-wyvern/bite]
+          {:id :creatures-wyvern/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one creature. _Hit: _11 (2d6 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-wyvern/claws]
+          {:id :creatures-wyvern/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d8+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-wyvern/stinger]
+          {:id :creatures-wyvern/stinger
+           :name "Stinger"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 10 ft., one creature. _Hit: _11 (2d6 + 4) piercing damage. The target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :piercing
+           :dice "2d6+4"
+           :to-hit 7}))}
+  {:id :creatures/xorn
+   :name "Xorn"
+   :ac 19
+   :challenge 5
+   :hit-points "7d8 + 42"
+   :abilities {:str 17 :dex 10 :con 22 :int 11 :wis 10 :cha 11}
+   :senses "darkvision 60 ft., tremorsense 60 ft., passive Perception 16"
+   :size :medium
+   :type :elemental
+   :speed "20 ft., burrow 20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-xorn/earth-glide
+           :name "Earth Glide"
+           :desc "The xorn can burrow through nonmagical, unworked earth and stone. While doing so, the xorn doesn’t disturb the material it moves through."})
+        (provide-feature
+          {:id :creatures-xorn/stone-camouflage
+           :name "Stone Camouflage"
+           :desc "The xorn has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."})
+        (provide-feature
+          {:id :creatures-xorn/treasure-sense
+           :name "Treasure Sense"
+           :desc "The xorn can pinpoint, by scent, the location of precious metals and stones, such as coins and gems, within 60 feet of it."})
+        (provide-attr
+          [:attacks :creatures-xorn/multiattack]
+          {:id :creatures-xorn/multiattack
+           :name "Multiattack"
+           :desc "The xorn makes three claw attacks and one bite attack."})
+        (provide-attr
+          [:attacks :creatures-xorn/claw]
+          {:id :creatures-xorn/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d6+3"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-xorn/bite]
+          {:id :creatures-xorn/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _13 (3d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "3d6+3"
+           :to-hit 6}))}
+  {:id :creatures/zombie
+   :name "Zombie"
+   :ac 8
+   :challenge 0.25
+   :hit-points "3d8 + 9"
+   :abilities {:str 13 :dex 6 :con 16 :int 3 :wis 6 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 8"
+   :size :medium
+   :type :undead
+   :speed "20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-zombie/undead-fortitude
+           :name "Undead Fortitude"
+           :desc "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5 + the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."})
+        (provide-attr
+          [:attacks :creatures-zombie/slam]
+          {:id :creatures-zombie/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6+1"
+           :to-hit 3}))}
+  {:id :creatures/ogre-zombie
+   :name "Ogre Zombie"
+   :ac 8
+   :challenge 2
+   :hit-points "9d10 + 36"
+   :abilities {:str 19 :dex 6 :con 18 :int 3 :wis 6 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 8"
+   :size :large
+   :type :undead
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-ogre-zombie/undead-fortitude
+           :name "Undead Fortitude"
+           :desc "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5 + the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."})
+        (provide-attr
+          [:attacks :creatures-ogre-zombie/morningstar]
+          {:id :creatures-ogre-zombie/morningstar
+           :name "Morningstar"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+4"
+           :to-hit 6}))}
+  {:id :creatures/ape
+   :name "Ape"
+   :ac 12
+   :challenge 0.5
+   :hit-points "3d8 + 6"
+   :abilities {:str 16 :dex 14 :con 14 :int 6 :wis 12 :cha 7}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :beast
+   :speed "30 ft., climb 30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-ape/multiattack]
+          {:id :creatures-ape/multiattack
+           :name "Multiattack"
+           :desc "The ape makes two fist attacks."})
+        (provide-attr
+          [:attacks :creatures-ape/fist]
+          {:id :creatures-ape/fist
+           :name "Fist"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-ape/rock]
+          {:id :creatures-ape/rock
+           :name "Rock"
+           :desc "_Ranged Weapon Attack: _+5 to hit, range 25/50 ft., one target. _Hit: _6 (1d6 + 3) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6+3"
+           :to-hit 5}))}
+  {:id :creatures/awakened-shrub
+   :name "Awakened Shrub"
+   :ac 9
+   :challenge 0
+   :hit-points "3d6"
+   :abilities {:str 3 :dex 8 :con 11 :int 10 :wis 10 :cha 6}
+   :senses "passive Perception 10"
+   :size :small
+   :type :plant
+   :speed "20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-awakened-shrub/false-appearance
+           :name "False Appearance"
+           :desc "While the shrub remains motionless, it is indistinguishable from a normal shrub."})
+        (provide-attr
+          [:attacks :creatures-awakened-shrub/rake]
+          {:id :creatures-awakened-shrub/rake
+           :name "Rake"
+           :desc "_Melee Weapon Attack: _+1 to hit, reach 5 ft., one target. _Hit: _1 (1d4 − 1) slashing damage."
+           :to-hit 1}))}
+  {:id :creatures/awakened-tree
+   :name "Awakened Tree"
+   :ac 13
+   :challenge 2
+   :hit-points "7d12 + 14"
+   :abilities {:str 19 :dex 6 :con 15 :int 10 :wis 10 :cha 7}
+   :senses "passive Perception 10"
+   :size :huge
+   :type :plant
+   :speed "20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-awakened-tree/false-appearance
+           :name "False Appearance"
+           :desc "While the tree remains motionless, it is indistinguishable from a normal tree."})
+        (provide-attr
+          [:attacks :creatures-awakened-tree/slam]
+          {:id :creatures-awakened-tree/slam
+           :name "Slam"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one target. _Hit: _14 (3d6 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d6+4"
+           :to-hit 6}))}
+  {:id :creatures/axe-beak
+   :name "Axe Beak"
+   :ac 11
+   :challenge 0.25
+   :hit-points "3d10 + 3"
+   :abilities {:str 14 :dex 12 :con 12 :int 2 :wis 10 :cha 5}
+   :senses "passive Perception 10"
+   :size :large
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-axe-beak/beak]
+          {:id :creatures-axe-beak/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _6 (1d8 + 2) slashing damage."
+           :damage :slashing
+           :dice "1d8+2"
+           :to-hit 4}))}
+  {:id :creatures/baboon
+   :name "Baboon"
+   :ac 12
+   :challenge 0
+   :hit-points "1d6"
+   :abilities {:str 8 :dex 14 :con 11 :int 4 :wis 12 :cha 6}
+   :senses "passive Perception 11"
+   :size :small
+   :type :beast
+   :speed "30 ft., climb 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-baboon/pack-tactics
+           :name "Pack Tactics"
+           :desc "The baboon has advantage on an attack roll against a creature if at least one of the baboon’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-baboon/bite]
+          {:id :creatures-baboon/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+1 to hit, reach 5 ft., one target. _Hit: _1 (1d4 − 1) piercing damage."
+           :to-hit 1}))}
+  {:id :creatures/badger
+   :name "Badger"
+   :ac 10
+   :challenge 0
+   :hit-points "1d4 + 1"
+   :abilities {:str 4 :dex 11 :con 12 :int 2 :wis 12 :cha 5}
+   :senses "darkvision 30 ft., passive Perception 11"
+   :size :tiny
+   :type :beast
+   :speed "20 ft., burrow 5 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-badger/keen-smell
+           :name "Keen Smell"
+           :desc "The badger has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-attr
+          [:attacks :creatures-badger/bite]
+          {:id :creatures-badger/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _1 piercing damage."
+           :to-hit 2}))}
+  {:id :creatures/bat
+   :name "Bat"
+   :ac 12
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 2 :dex 15 :con 8 :int 2 :wis 12 :cha 4}
+   :senses "blindsight 60 ft., passive Perception 11"
+   :size :tiny
+   :type :beast
+   :speed "5 ft., fly 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-bat/echolocation
+           :name "Echolocation"
+           :desc "The bat can’t use its blindsight while deafened."})
+        (provide-feature
+          {:id :creatures-bat/keen-hearing
+           :name "Keen Hearing"
+           :desc "The bat has advantage on Wisdom (Perception) checks that rely on hearing."})
+        (provide-attr
+          [:attacks :creatures-bat/bite]
+          {:id :creatures-bat/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+0 to hit, reach 5 ft., one creature. _Hit: _1 piercing damage."
+           :to-hit 0}))}
+  {:id :creatures/black-bear
+   :name "Black Bear"
+   :ac 11
+   :challenge 0.5
+   :hit-points "3d8 + 6"
+   :abilities {:str 15 :dex 10 :con 14 :int 2 :wis 12 :cha 7}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :beast
+   :speed "40 ft., climb 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-black-bear/keen-smell
+           :name "Keen Smell"
+           :desc "The bear has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-attr
+          [:attacks :creatures-black-bear/multiattack]
+          {:id :creatures-black-bear/multiattack
+           :name "Multiattack"
+           :desc "The bear makes two attacks: one with its bite and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-black-bear/bite]
+          {:id :creatures-black-bear/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 3})
+        (provide-attr
+          [:attacks :creatures-black-bear/claws]
+          {:id :creatures-black-bear/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _7 (2d4 + 2) slashing damage."
+           :damage :slashing
+           :dice "2d4+2"
+           :to-hit 3}))}
+  {:id :creatures/blink-dog
+   :name "Blink Dog"
+   :ac 13
+   :challenge 0.25
+   :hit-points "4d8 + 4"
+   :abilities {:str 12 :dex 17 :con 12 :int 10 :wis 13 :cha 11}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :fey
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-blink-dog/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The dog has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-attr
+          [:attacks :creatures-blink-dog/bite]
+          {:id :creatures-blink-dog/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d6+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-blink-dog/teleport
+           :name "Teleport (Recharge 4–6)"
+           :desc "The dog magically teleports, along with any equipment it is wearing or carrying, up to 40 feet to an unoccupied space it can see. Before or after teleporting, the dog can make one bite attack."}))}
+  {:id :creatures/blood-hawk
+   :name "Blood Hawk"
+   :ac 12
+   :challenge 0.125
+   :hit-points "2d6"
+   :abilities {:str 6 :dex 14 :con 10 :int 3 :wis 14 :cha 5}
+   :senses "passive Perception 14"
+   :size :small
+   :type :beast
+   :speed "10 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-blood-hawk/keen-sight
+           :name "Keen Sight"
+           :desc "The hawk has advantage on Wisdom (Perception) checks that rely on sight."})
+        (provide-feature
+          {:id :creatures-blood-hawk/pack-tactics
+           :name "Pack Tactics"
+           :desc "The hawk has advantage on an attack roll against a creature if at least one of the hawk’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-blood-hawk/beak]
+          {:id :creatures-blood-hawk/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _4 (1d4 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4}))}
+  {:id :creatures/boar
+   :name "Boar"
+   :ac 11
+   :challenge 0.25
+   :hit-points "2d8 + 2"
+   :abilities {:str 13 :dex 11 :con 12 :int 2 :wis 9 :cha 5}
+   :senses "passive Perception 9"
+   :size :medium
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-boar/charge
+           :name "Charge"
+           :desc "If the boar moves at least 20 feet straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 3 (1d6) slashing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."})
+        (provide-feature
+          {:id :creatures-boar/relentless
+           :name "Relentless (Recharges after a Short or Long Rest)"
+           :desc "If the boar takes 7 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."})
+        (provide-attr
+          [:attacks :creatures-boar/tusk]
+          {:id :creatures-boar/tusk
+           :name "Tusk"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) slashing damage."
+           :damage :slashing
+           :dice "1d6+1"
+           :to-hit 3}))}
+  {:id :creatures/brown-bear
+   :name "Brown Bear"
+   :ac 11
+   :challenge 1
+   :hit-points "4d10 + 12"
+   :abilities {:str 19 :dex 10 :con 16 :int 2 :wis 13 :cha 7}
+   :senses "passive Perception 13"
+   :size :large
+   :type :beast
+   :speed "40 ft., climb 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-brown-bear/keen-smell
+           :name "Keen Smell"
+           :desc "The bear has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-attr
+          [:attacks :creatures-brown-bear/multiattack]
+          {:id :creatures-brown-bear/multiattack
+           :name "Multiattack"
+           :desc "The bear makes two attacks: one with its bite and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-brown-bear/bite]
+          {:id :creatures-brown-bear/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _8 (1d8 + 4) piercing damage."
+           :damage :piercing
+           :dice "1d8+4"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-brown-bear/claws]
+          {:id :creatures-brown-bear/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) slashing damage."
+           :damage :slashing
+           :dice "2d6+4"
+           :to-hit 5}))}
+  {:id :creatures/camel
+   :name "Camel"
+   :ac 9
+   :challenge 0.125
+   :hit-points "2d10 + 4"
+   :abilities {:str 16 :dex 8 :con 14 :int 2 :wis 8 :cha 5}
+   :senses "passive Perception 9"
+   :size :large
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-camel/bite]
+          {:id :creatures-camel/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _2 (1d4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d4"
+           :to-hit 5}))}
+  {:id :creatures/cat
+   :name "Cat"
+   :ac 12
+   :challenge 0
+   :hit-points "1d4"
+   :abilities {:str 3 :dex 15 :con 10 :int 3 :wis 12 :cha 7}
+   :senses "passive Perception 13"
+   :size :tiny
+   :type :beast
+   :speed "40 ft., climb 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-cat/keen-smell
+           :name "Keen Smell"
+           :desc "The cat has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-attr
+          [:attacks :creatures-cat/claws]
+          {:id :creatures-cat/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+0 to hit, reach 5 ft., one target. _Hit: _1 slashing damage."
+           :to-hit 0}))}
+  {:id :creatures/constrictor-snake
+   :name "Constrictor Snake"
+   :ac 12
+   :challenge 0.25
+   :hit-points "2d10 + 2"
+   :abilities {:str 15 :dex 14 :con 12 :int 1 :wis 10 :cha 3}
+   :senses "blindsight 10 ft., passive Perception 10"
+   :size :large
+   :type :beast
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-constrictor-snake/bite]
+          {:id :creatures-constrictor-snake/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-constrictor-snake/constrict]
+          {:id :creatures-constrictor-snake/constrict
+           :name "Constrict"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _6 (1d8 + 2) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the creature is restrained, and the snake can’t constrict another target."
+           :damage :bludgeoning
+           :dice "1d8+2"
+           :to-hit 4}))}
+  {:id :creatures/crab
+   :name "Crab"
+   :ac 11
+   :challenge 0
+   :hit-points "1d4"
+   :abilities {:str 2 :dex 11 :con 10 :int 1 :wis 8 :cha 2}
+   :senses "blindsight 30 ft., passive Perception 9"
+   :size :tiny
+   :type :beast
+   :speed "20 ft., swim 20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-crab/amphibious
+           :name "Amphibious"
+           :desc "The crab can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-crab/claw]
+          {:id :creatures-crab/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+0 to hit, reach 5 ft., one target. _Hit: _1 bludgeoning damage."
+           :to-hit 0}))}
+  {:id :creatures/crocodile
+   :name "Crocodile"
+   :ac 12
+   :challenge 0.5
+   :hit-points "3d10 + 3"
+   :abilities {:str 15 :dex 10 :con 13 :int 2 :wis 10 :cha 5}
+   :senses "passive Perception 10"
+   :size :large
+   :type :beast
+   :speed "20 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-crocodile/hold-breath
+           :name "Hold Breath"
+           :desc "The crocodile can hold its breath for 15 minutes."})
+        (provide-attr
+          [:attacks :creatures-crocodile/bite]
+          {:id :creatures-crocodile/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _7 (1d10 + 2) piercing damage, and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained, and the crocodile can’t bite another target."
+           :damage :piercing
+           :dice "1d10+2"
+           :to-hit 4}))}
+  {:id :creatures/death-dog
+   :name "Death Dog"
+   :ac 12
+   :challenge 1
+   :hit-points "6d8 + 12"
+   :abilities {:str 15 :dex 14 :con 14 :int 3 :wis 13 :cha 6}
+   :senses "darkvision 120 ft., passive Perception 15"
+   :size :medium
+   :type :monstrosity
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-death-dog/two-headed
+           :name "Two-Headed"
+           :desc "The dog has advantage on Wisdom (Perception) checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, or knocked unconscious."})
+        (provide-attr
+          [:attacks :creatures-death-dog/multiattack]
+          {:id :creatures-death-dog/multiattack
+           :name "Multiattack"
+           :desc "The dog makes two bite attacks."})
+        (provide-attr
+          [:attacks :creatures-death-dog/bite]
+          {:id :creatures-death-dog/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage. If the target is a creature, it must succeed on a DC 12 Constitution saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the creature must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. This reduction lasts until the disease is cured. The creature dies if the disease reduces its hit point maximum to 0."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/deer
+   :name "Deer"
+   :ac 13
+   :challenge 0
+   :hit-points "1d8"
+   :abilities {:str 11 :dex 16 :con 11 :int 2 :wis 14 :cha 5}
+   :senses "passive Perception 12"
+   :size :medium
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-deer/bite]
+          {:id :creatures-deer/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _2 (1d4) piercing damage."
+           :damage :piercing
+           :dice "1d4"
+           :to-hit 2}))}
+  {:id :creatures/dire-wolf
+   :name "Dire Wolf"
+   :ac 14
+   :challenge 1
+   :hit-points "5d10 + 10"
+   :abilities {:str 17 :dex 15 :con 15 :int 3 :wis 12 :cha 7}
+   :senses "passive Perception 13"
+   :size :large
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-dire-wolf/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-feature
+          {:id :creatures-dire-wolf/pack-tactics
+           :name "Pack Tactics"
+           :desc "The wolf has advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-dire-wolf/bite]
+          {:id :creatures-dire-wolf/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+           :damage :piercing
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/draft-horse
+   :name "Draft Horse"
+   :ac 10
+   :challenge 0.25
+   :hit-points "3d10 + 3"
+   :abilities {:str 18 :dex 10 :con 12 :int 2 :wis 11 :cha 7}
+   :senses "passive Perception 10"
+   :size :large
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-draft-horse/hooves]
+          {:id :creatures-draft-horse/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _9 (2d4 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d4+4"
+           :to-hit 6}))}
+  {:id :creatures/eagle
+   :name "Eagle"
+   :ac 12
+   :challenge 0
+   :hit-points "1d6"
+   :abilities {:str 6 :dex 15 :con 10 :int 2 :wis 14 :cha 7}
+   :senses "passive Perception 14"
+   :size :small
+   :type :beast
+   :speed "10 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-eagle/keen-sight
+           :name "Keen Sight"
+           :desc "The eagle has advantage on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-eagle/talons]
+          {:id :creatures-eagle/talons
+           :name "Talons"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _4 (1d4 + 2) slashing damage."
+           :damage :slashing
+           :dice "1d4+2"
+           :to-hit 4}))}
+  {:id :creatures/elephant
+   :name "Elephant"
+   :ac 12
+   :challenge 4
+   :hit-points "8d12 + 24"
+   :abilities {:str 22 :dex 9 :con 17 :int 3 :wis 11 :cha 6}
+   :senses "passive Perception 10"
+   :size :huge
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-elephant/trampling-charge
+           :name "Trampling Charge"
+           :desc "If the elephant moves at least 20 feet straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 12 Strength saving throw or be knocked prone. If the target is prone, the elephant can make one stomp attack against it as a bonus action."})
+        (provide-attr
+          [:attacks :creatures-elephant/gore]
+          {:id :creatures-elephant/gore
+           :name "Gore"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _19 (3d8 + 6) piercing damage."
+           :damage :piercing
+           :dice "3d8+6"
+           :to-hit 8})
+        (provide-attr
+          [:attacks :creatures-elephant/stomp]
+          {:id :creatures-elephant/stomp
+           :name "Stomp"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one prone creature. _Hit: _22 (3d10 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d10+6"
+           :to-hit 8}))}
+  {:id :creatures/elk
+   :name "Elk"
+   :ac 10
+   :challenge 0.25
+   :hit-points "2d10 + 2"
+   :abilities {:str 16 :dex 10 :con 12 :int 2 :wis 10 :cha 6}
+   :senses "passive Perception 10"
+   :size :large
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-elk/charge
+           :name "Charge"
+           :desc "If the elk moves at least 20 feet straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."})
+        (provide-attr
+          [:attacks :creatures-elk/ram]
+          {:id :creatures-elk/ram
+           :name "Ram"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-elk/hooves]
+          {:id :creatures-elk/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one prone creature. _Hit: _8 (2d4 + 3) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d4+3"
+           :to-hit 5}))}
+  {:id :creatures/flying-snake
+   :name "Flying Snake"
+   :ac 14
+   :challenge 0.125
+   :hit-points "2d4"
+   :abilities {:str 4 :dex 18 :con 11 :int 2 :wis 12 :cha 5}
+   :senses "blindsight 10 ft., passive Perception 11"
+   :size :tiny
+   :type :beast
+   :speed "30 ft., fly 60 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-flying-snake/flyby
+           :name "Flyby"
+           :desc "The snake doesn’t provoke opportunity attacks when it flies out of an enemy’s reach."})
+        (provide-attr
+          [:attacks :creatures-flying-snake/bite]
+          {:id :creatures-flying-snake/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _1 piercing damage plus 7 (3d4) poison damage."
+           :damage :poison
+           :dice "3d4"
+           :to-hit 6}))}
+  {:id :creatures/frog
+   :name "Frog"
+   :ac 11
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 1 :dex 13 :con 8 :int 1 :wis 8 :cha 3}
+   :senses "darkvision 30 ft., passive Perception 11"
+   :size :tiny
+   :type :beast
+   :speed "20 ft., swim 20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-frog/amphibious
+           :name "Amphibious"
+           :desc "The frog can breathe air and water."})
+        (provide-feature
+          {:id :creatures-frog/standing-leap
+           :name "Standing Leap"
+           :desc "The frog’s long jump is up to 10 feet and its high jump is up to 5 feet, with or without a running start."}))}
+  {:id :creatures/giant-ape
+   :name "Giant Ape"
+   :ac 12
+   :challenge 7
+   :hit-points "15d12 + 60"
+   :abilities {:str 23 :dex 14 :con 18 :int 7 :wis 12 :cha 7}
+   :senses "passive Perception 14"
+   :size :huge
+   :type :beast
+   :speed "40 ft., climb 40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-giant-ape/multiattack]
+          {:id :creatures-giant-ape/multiattack
+           :name "Multiattack"
+           :desc "The ape makes two fist attacks."})
+        (provide-attr
+          [:attacks :creatures-giant-ape/fist]
+          {:id :creatures-giant-ape/fist
+           :name "Fist"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 10 ft., one target. _Hit: _22 (3d10 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "3d10+6"
+           :to-hit 9})
+        (provide-attr
+          [:attacks :creatures-giant-ape/rock]
+          {:id :creatures-giant-ape/rock
+           :name "Rock"
+           :desc "_Ranged Weapon Attack: _+9 to hit, range 50/100 ft., one target. _Hit: _30 (7d6 + 6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "7d6+6"
+           :to-hit 9}))}
+  {:id :creatures/giant-badger
+   :name "Giant Badger"
+   :ac 10
+   :challenge 0.25
+   :hit-points "2d8 + 4"
+   :abilities {:str 13 :dex 10 :con 15 :int 2 :wis 12 :cha 5}
+   :senses "darkvision 30 ft., passive Perception 11"
+   :size :medium
+   :type :beast
+   :speed "30 ft., burrow 10 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-badger/keen-smell
+           :name "Keen Smell"
+           :desc "The badger has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-attr
+          [:attacks :creatures-giant-badger/multiattack]
+          {:id :creatures-giant-badger/multiattack
+           :name "Multiattack"
+           :desc "The badger makes two attacks: one with its bite and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-giant-badger/bite]
+          {:id :creatures-giant-badger/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d6+1"
+           :to-hit 3})
+        (provide-attr
+          [:attacks :creatures-giant-badger/claws]
+          {:id :creatures-giant-badger/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _6 (2d4 + 1) slashing damage."
+           :damage :slashing
+           :dice "2d4+1"
+           :to-hit 3}))}
+  {:id :creatures/giant-bat
+   :name "Giant Bat"
+   :ac 13
+   :challenge 0.25
+   :hit-points "4d10"
+   :abilities {:str 15 :dex 16 :con 11 :int 2 :wis 12 :cha 6}
+   :senses "blindsight 60 ft., passive Perception 11"
+   :size :large
+   :type :beast
+   :speed "10 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-bat/echolocation
+           :name "Echolocation"
+           :desc "The bat can’t use its blindsight while deafened."})
+        (provide-feature
+          {:id :creatures-giant-bat/keen-hearing
+           :name "Keen Hearing"
+           :desc "The bat has advantage on Wisdom (Perception) checks that rely on hearing."})
+        (provide-attr
+          [:attacks :creatures-giant-bat/bite]
+          {:id :creatures-giant-bat/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/giant-boar
+   :name "Giant Boar"
+   :ac 12
+   :challenge 2
+   :hit-points "5d10 + 15"
+   :abilities {:str 17 :dex 10 :con 16 :int 2 :wis 7 :cha 5}
+   :senses "passive Perception 8"
+   :size :large
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-boar/charge
+           :name "Charge"
+           :desc "If the boar moves at least 20 feet straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 7 (2d6) slashing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."})
+        (provide-feature
+          {:id :creatures-giant-boar/relentless
+           :name "Relentless (Recharges after a Short or Long Rest)"
+           :desc "If the boar takes 10 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."})
+        (provide-attr
+          [:attacks :creatures-giant-boar/tusk]
+          {:id :creatures-giant-boar/tusk
+           :name "Tusk"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/giant-centipede
+   :name "Giant Centipede"
+   :ac 13
+   :challenge 0.25
+   :hit-points "1d6 + 1"
+   :abilities {:str 5 :dex 14 :con 12 :int 1 :wis 7 :cha 3}
+   :senses "blindsight 30 ft., passive Perception 8"
+   :size :small
+   :type :beast
+   :speed "30 ft., climb 30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-giant-centipede/bite]
+          {:id :creatures-giant-centipede/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _4 (1d4 + 2) piercing damage, and the target must succeed on a DC 11 Constitution saving throw or take 10 (3d6) poison damage. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4}))}
+  {:id :creatures/giant-constrictor-snake
+   :name "Giant Constrictor Snake"
+   :ac 12
+   :challenge 2
+   :hit-points "8d12 + 8"
+   :abilities {:str 19 :dex 14 :con 12 :int 1 :wis 10 :cha 3}
+   :senses "blindsight 10 ft., passive Perception 12"
+   :size :huge
+   :type :beast
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-giant-constrictor-snake/bite]
+          {:id :creatures-giant-constrictor-snake/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one creature. _Hit: _11 (2d6 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d6+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-giant-constrictor-snake/constrict]
+          {:id :creatures-giant-constrictor-snake/constrict
+           :name "Constrict"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one creature. _Hit: _13 (2d8 + 4) bludgeoning damage, and the target is grappled (escape DC 16). Until this grapple ends, the creature is restrained, and the snake can’t constrict another target."
+           :damage :bludgeoning
+           :dice "2d8+4"
+           :to-hit 6}))}
+  {:id :creatures/giant-crab
+   :name "Giant Crab"
+   :ac 15
+   :challenge 0.125
+   :hit-points "3d8"
+   :abilities {:str 13 :dex 15 :con 11 :int 1 :wis 9 :cha 3}
+   :senses "blindsight 30 ft., passive Perception 9"
+   :size :medium
+   :type :beast
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-crab/amphibious
+           :name "Amphibious"
+           :desc "The crab can breathe air and water."})
+        (provide-attr
+          [:attacks :creatures-giant-crab/claw]
+          {:id :creatures-giant-crab/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) bludgeoning damage, and the target is grappled (escape DC 11). The crab has two claws, each of which can grapple only one target."
+           :damage :bludgeoning
+           :dice "1d6+1"
+           :to-hit 3}))}
+  {:id :creatures/giant-crocodile
+   :name "Giant Crocodile"
+   :ac 14
+   :challenge 5
+   :hit-points "9d12 + 27"
+   :abilities {:str 21 :dex 9 :con 17 :int 2 :wis 10 :cha 7}
+   :senses "passive Perception 10"
+   :size :huge
+   :type :beast
+   :speed "30 ft., swim 50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-crocodile/hold-breath
+           :name "Hold Breath"
+           :desc "The crocodile can hold its breath for 30 minutes."})
+        (provide-attr
+          [:attacks :creatures-giant-crocodile/multiattack]
+          {:id :creatures-giant-crocodile/multiattack
+           :name "Multiattack"
+           :desc "The crocodile makes two attacks: one with its bite and one with its tail."})
+        (provide-attr
+          [:attacks :creatures-giant-crocodile/bite]
+          {:id :creatures-giant-crocodile/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 5 ft., one target. _Hit: _21 (3d10 + 5) piercing damage, and the target is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the crocodile can’t bite another target."
+           :damage :piercing
+           :dice "3d10+5"
+           :to-hit 8})
+        (provide-attr
+          [:attacks :creatures-giant-crocodile/tail]
+          {:id :creatures-giant-crocodile/tail
+           :name "Tail"
+           :desc "_Melee Weapon Attack: _+8 to hit, reach 10 ft., one target not grappled by the crocodile. _Hit: _14 (2d8 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 16 Strength saving throw or be knocked prone."
+           :damage :bludgeoning
+           :dice "2d8+5"
+           :to-hit 8}))}
+  {:id :creatures/giant-eagle
+   :name "Giant Eagle"
+   :ac 13
+   :challenge 1
+   :hit-points "4d10 + 4"
+   :abilities {:str 16 :dex 17 :con 13 :int 8 :wis 14 :cha 10}
+   :senses "passive Perception 14"
+   :size :large
+   :type :beast
+   :speed "10 ft., fly 80 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-eagle/keen-sight
+           :name "Keen Sight"
+           :desc "The eagle has advantage on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-giant-eagle/multiattack]
+          {:id :creatures-giant-eagle/multiattack
+           :name "Multiattack"
+           :desc "The eagle makes two attacks: one with its beak and one with its talons."})
+        (provide-attr
+          [:attacks :creatures-giant-eagle/beak]
+          {:id :creatures-giant-eagle/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-giant-eagle/talons]
+          {:id :creatures-giant-eagle/talons
+           :name "Talons"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/giant-elk
+   :name "Giant Elk"
+   :ac 14
+   :challenge 2
+   :hit-points "5d12 + 10"
+   :abilities {:str 19 :dex 16 :con 14 :int 7 :wis 14 :cha 10}
+   :senses "passive Perception 14"
+   :size :huge
+   :type :beast
+   :speed "60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-elk/charge
+           :name "Charge"
+           :desc "If the elk moves at least 20 feet straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."})
+        (provide-attr
+          [:attacks :creatures-giant-elk/ram]
+          {:id :creatures-giant-elk/ram
+           :name "Ram"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one target. _Hit: _11 (2d6 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d6+4"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-giant-elk/hooves]
+          {:id :creatures-giant-elk/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one prone creature. _Hit: _22 (4d8 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "4d8+4"
+           :to-hit 6}))}
+  {:id :creatures/giant-fire-beetle
+   :name "Giant Fire Beetle"
+   :ac 13
+   :challenge 0
+   :hit-points "1d6 + 1"
+   :abilities {:str 8 :dex 10 :con 12 :int 1 :wis 7 :cha 3}
+   :senses "blindsight 30 ft., passive Perception 8"
+   :size :small
+   :type :beast
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-fire-beetle/illumination
+           :name "Illumination"
+           :desc "The beetle sheds bright light in a 10-foot radius and dim light for an additional 10 feet."})
+        (provide-attr
+          [:attacks :creatures-giant-fire-beetle/bite]
+          {:id :creatures-giant-fire-beetle/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+1 to hit, reach 5 ft., one target. _Hit: _2 (1d6 − 1) slashing damage."
+           :to-hit 1}))}
+  {:id :creatures/giant-frog
+   :name "Giant Frog"
+   :ac 11
+   :challenge 0.25
+   :hit-points "4d8"
+   :abilities {:str 12 :dex 13 :con 11 :int 2 :wis 10 :cha 3}
+   :senses "darkvision 30 ft., passive Perception 12"
+   :size :medium
+   :type :beast
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-frog/amphibious
+           :name "Amphibious"
+           :desc "The frog can breathe air and water."})
+        (provide-feature
+          {:id :creatures-giant-frog/standing-leap
+           :name "Standing Leap"
+           :desc "The frog’s long jump is up to 20 feet and its high jump is up to 10 feet, with or without a running start."})
+        (provide-attr
+          [:attacks :creatures-giant-frog/bite]
+          {:id :creatures-giant-frog/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) piercing damage, and the target is grappled (escape DC 11). Until this grapple ends, the target is restrained, and the frog can’t bite another target."
+           :damage :piercing
+           :dice "1d6+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-giant-frog/swallow
+           :name "Swallow"
+           :desc "The frog makes one bite attack against a Small or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the frog, and it takes 5 (2d4) acid damage at the start of each of the frog’s turns. The frog can have only one target swallowed at a time."}))}
+  {:id :creatures/giant-goat
+   :name "Giant Goat"
+   :ac 11
+   :challenge 0.5
+   :hit-points "3d10 + 3"
+   :abilities {:str 17 :dex 11 :con 12 :int 3 :wis 12 :cha 6}
+   :senses "passive Perception 11"
+   :size :large
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-goat/charge
+           :name "Charge"
+           :desc "If the goat moves at least 20 feet straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 5 (2d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."})
+        (provide-feature
+          {:id :creatures-giant-goat/sure-footed
+           :name "Sure-Footed"
+           :desc "The goat has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."})
+        (provide-attr
+          [:attacks :creatures-giant-goat/ram]
+          {:id :creatures-giant-goat/ram
+           :name "Ram"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _8 (2d4 + 3) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d4+3"
+           :to-hit 5}))}
+  {:id :creatures/giant-hyena
+   :name "Giant Hyena"
+   :ac 12
+   :challenge 1
+   :hit-points "6d10 + 12"
+   :abilities {:str 16 :dex 14 :con 14 :int 2 :wis 12 :cha 7}
+   :senses "passive Perception 13"
+   :size :large
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-hyena/rampage
+           :name "Rampage"
+           :desc "When the hyena reduces a creature to 0 hit points with a melee attack on its turn, the hyena can take a bonus action to move up to half its speed and make a bite attack."})
+        (provide-attr
+          [:attacks :creatures-giant-hyena/bite]
+          {:id :creatures-giant-hyena/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/giant-lizard
+   :name "Giant Lizard"
+   :ac 12
+   :challenge 0.25
+   :hit-points "3d10 + 3"
+   :abilities {:str 15 :dex 12 :con 13 :int 2 :wis 10 :cha 5}
+   :senses "darkvision 30 ft., passive Perception 10"
+   :size :large
+   :type :beast
+   :speed "30 ft., climb 30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-giant-lizard/bite]
+          {:id :creatures-giant-lizard/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _6 (1d8 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 4}))}
+  {:id :creatures/giant-octopus
+   :name "Giant Octopus"
+   :ac 11
+   :challenge 1
+   :hit-points "8d10 + 8"
+   :abilities {:str 17 :dex 13 :con 13 :int 4 :wis 10 :cha 4}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :large
+   :type :beast
+   :speed "10 ft., swim 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-octopus/hold-breath
+           :name "Hold Breath"
+           :desc "While out of water, the octopus can hold its breath for 1 hour."})
+        (provide-feature
+          {:id :creatures-giant-octopus/underwater-camouflage
+           :name "Underwater Camouflage"
+           :desc "The octopus has advantage on Dexterity (Stealth) checks made while underwater."})
+        (provide-feature
+          {:id :creatures-giant-octopus/water-breathing
+           :name "Water Breathing"
+           :desc "The octopus can breathe only underwater."})
+        (provide-attr
+          [:attacks :creatures-giant-octopus/tentacles]
+          {:id :creatures-giant-octopus/tentacles
+           :name "Tentacles"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 15 ft., one target. _Hit: _10 (2d6 + 3) bludgeoning damage. If the target is a creature, it is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the octopus can’t use its tentacles on another target."
+           :damage :bludgeoning
+           :dice "2d6+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-giant-octopus/ink-cloud
+           :name "Ink Cloud (Recharges after a Short or Long Rest)"
+           :desc "A 20-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action."}))}
+  {:id :creatures/giant-owl
+   :name "Giant Owl"
+   :ac 12
+   :challenge 0.25
+   :hit-points "3d10 + 3"
+   :abilities {:str 13 :dex 15 :con 12 :int 8 :wis 13 :cha 10}
+   :senses "darkvision 120 ft., passive Perception 15"
+   :size :large
+   :type :beast
+   :speed "5 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-owl/flyby
+           :name "Flyby"
+           :desc "The owl doesn’t provoke opportunity attacks when it flies out of an enemy’s reach."})
+        (provide-feature
+          {:id :creatures-giant-owl/keen-hearing-and-sight
+           :name "Keen Hearing and Sight"
+           :desc "The owl has advantage on Wisdom (Perception) checks that rely on hearing or sight."})
+        (provide-attr
+          [:attacks :creatures-giant-owl/talons]
+          {:id :creatures-giant-owl/talons
+           :name "Talons"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _8 (2d6 + 1) slashing damage."
+           :damage :slashing
+           :dice "2d6+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-giant-owl/giant-owls
+           :name "Giant owls"
+           :desc "often befriend fey and other sylvan creatures and are guardians of their woodland realms."}))}
+  {:id :creatures/giant-poisonous-snake
+   :name "Giant Poisonous Snake"
+   :ac 14
+   :challenge 0.25
+   :hit-points "2d8 + 2"
+   :abilities {:str 10 :dex 18 :con 13 :int 2 :wis 10 :cha 3}
+   :senses "blindsight 10 ft., passive Perception 12"
+   :size :medium
+   :type :beast
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-giant-poisonous-snake/bite]
+          {:id :creatures-giant-poisonous-snake/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 10 ft., one target. _Hit: _6 (1d4 + 4) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :piercing
+           :dice "1d4+4"
+           :to-hit 6}))}
+  {:id :creatures/giant-rat
+   :name "Giant Rat"
+   :ac 12
+   :challenge 0.125
+   :hit-points "2d6"
+   :abilities {:str 7 :dex 15 :con 11 :int 2 :wis 10 :cha 4}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :small
+   :type :beast
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-rat/keen-smell
+           :name "Keen Smell"
+           :desc "The rat has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-feature
+          {:id :creatures-giant-rat/pack-tactics
+           :name "Pack Tactics"
+           :desc "The rat has advantage on an attack roll against a creature if at least one of the rat’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-giant-rat/bite]
+          {:id :creatures-giant-rat/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _4 (1d4 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-giant-rat/variant-diseased-giant-rats
+           :name "Variant: Diseased Giant Rats"
+           :desc ""})
+        (provide-attr
+          [:attacks :creatures-giant-rat/bite]
+          {:id :creatures-giant-rat/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _4 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can’t regain hit points except by magical means, and the target’s hit point maximum decreases by 3 (1d6) every 24 hours. If the target’s hit point maximum drops to 0 as a result of this disease, the target dies."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4}))}
+  {:id :creatures/giant-scorpion
+   :name "Giant Scorpion"
+   :ac 15
+   :challenge 3
+   :hit-points "7d10 + 14"
+   :abilities {:str 15 :dex 13 :con 15 :int 1 :wis 9 :cha 3}
+   :senses "blindsight 60 ft., passive Perception 9"
+   :size :large
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-giant-scorpion/multiattack]
+          {:id :creatures-giant-scorpion/multiattack
+           :name "Multiattack"
+           :desc "The scorpion makes three attacks: two with its claws and one with its sting."})
+        (provide-attr
+          [:attacks :creatures-giant-scorpion/claw]
+          {:id :creatures-giant-scorpion/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _6 (1d8 + 2) bludgeoning damage, and the target is grappled (escape DC 12). The scorpion has two claws, each of which can grapple only one target."
+           :damage :bludgeoning
+           :dice "1d8+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-giant-scorpion/sting]
+          {:id :creatures-giant-scorpion/sting
+           :name "Sting"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _7 (1d10 + 2) piercing damage, and the target must make a DC 12 Constitution saving throw, taking 22 (4d10) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :piercing
+           :dice "1d10+2"
+           :to-hit 4}))}
+  {:id :creatures/giant-sea-horse
+   :name "Giant Sea Horse"
+   :ac 13
+   :challenge 0.5
+   :hit-points "3d10"
+   :abilities {:str 12 :dex 15 :con 11 :int 2 :wis 12 :cha 5}
+   :senses "passive Perception 11"
+   :size :large
+   :type :beast
+   :speed "0 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-sea-horse/charge
+           :name "Charge"
+           :desc "If the sea horse moves at least 20 feet straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) bludgeoning damage. It the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."})
+        (provide-feature
+          {:id :creatures-giant-sea-horse/water-breathing
+           :name "Water Breathing"
+           :desc "The sea horse can breathe only underwater."})
+        (provide-attr
+          [:attacks :creatures-giant-sea-horse/ram]
+          {:id :creatures-giant-sea-horse/ram
+           :name "Ram"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6+1"
+           :to-hit 3}))}
+  {:id :creatures/giant-shark
+   :name "Giant Shark"
+   :ac 13
+   :challenge 5
+   :hit-points "11d12 + 55"
+   :abilities {:str 23 :dex 11 :con 21 :int 1 :wis 10 :cha 5}
+   :senses "blindsight 60 ft., passive Perception 13"
+   :size :huge
+   :type :beast
+   :speed "0 ft., swim 50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-shark/blood-frenzy
+           :name "Blood Frenzy"
+           :desc "The shark has advantage on melee attack rolls against any creature that doesn’t have all its hit points."})
+        (provide-feature
+          {:id :creatures-giant-shark/water-breathing
+           :name "Water Breathing"
+           :desc "The shark can breathe only underwater."})
+        (provide-attr
+          [:attacks :creatures-giant-shark/bite]
+          {:id :creatures-giant-shark/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+9 to hit, reach 5 ft., one target. _Hit: _22 (3d10 + 6) piercing damage."
+           :damage :piercing
+           :dice "3d10+6"
+           :to-hit 9}))}
+  {:id :creatures/giant-spider
+   :name "Giant Spider"
+   :ac 14
+   :challenge 1
+   :hit-points "4d10 + 4"
+   :abilities {:str 14 :dex 16 :con 12 :int 2 :wis 11 :cha 4}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 10"
+   :size :large
+   :type :beast
+   :speed "30 ft., climb 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-spider/spider-climb
+           :name "Spider Climb"
+           :desc "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."})
+        (provide-feature
+          {:id :creatures-giant-spider/web-sense
+           :name "Web Sense"
+           :desc "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."})
+        (provide-feature
+          {:id :creatures-giant-spider/web-walker
+           :name "Web Walker"
+           :desc "The spider ignores movement restrictions caused by webbing."})
+        (provide-attr
+          [:attacks :creatures-giant-spider/bite]
+          {:id :creatures-giant-spider/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one creature. _Hit: _7 (1d8 + 3) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 9 (2d8) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+           :damage :piercing
+           :dice "1d8+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-giant-spider/web]
+          {:id :creatures-giant-spider/web
+           :name "Web (Recharge 5–6)"
+           :desc "_Ranged Weapon Attack: _+5 to hit, range 30/60 ft., one creature. _Hit: _The target is restrained by webbing. As an action, the restrained target can make a DC 12 Strength check, bursting the webbing on a success. The webbing can also be attacked and destroyed (AC 10; hp 5; vulnerability to fire damage; immunity to bludgeoning, poison, and psychic damage)."
+           :to-hit 5}))}
+  {:id :creatures/giant-toad
+   :name "Giant Toad"
+   :ac 11
+   :challenge 1
+   :hit-points "6d10 + 6"
+   :abilities {:str 15 :dex 13 :con 13 :int 2 :wis 10 :cha 3}
+   :senses "darkvision 30 ft., passive Perception 10"
+   :size :large
+   :type :beast
+   :speed "20 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-toad/amphibious
+           :name "Amphibious"
+           :desc "The toad can breathe air and water."})
+        (provide-feature
+          {:id :creatures-giant-toad/standing-leap
+           :name "Standing Leap"
+           :desc "The toad’s long jump is up to 20 feet and its high jump is up to 10 feet, with or without a running start."})
+        (provide-attr
+          [:attacks :creatures-giant-toad/bite]
+          {:id :creatures-giant-toad/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (1d10 + 2) piercing damage plus 5 (1d10) poison damage, and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the toad can’t bite another target."
+           :damage :piercing
+           :dice "1d10+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-giant-toad/swallow
+           :name "Swallow"
+           :desc "The toad makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the toad, and it takes 10 (3d6) acid damage at the start of each of the toad’s turns. The toad can have only one target swallowed at a time."}))}
+  {:id :creatures/giant-vulture
+   :name "Giant Vulture"
+   :ac 10
+   :challenge 1
+   :hit-points "3d10 + 6"
+   :abilities {:str 15 :dex 10 :con 15 :int 6 :wis 12 :cha 7}
+   :senses "passive Perception 13"
+   :size :large
+   :type :beast
+   :speed "10 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-vulture/keen-sight-and-smell
+           :name "Keen Sight and Smell"
+           :desc "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."})
+        (provide-feature
+          {:id :creatures-giant-vulture/pack-tactics
+           :name "Pack Tactics"
+           :desc "The vulture has advantage on an attack roll against a creature if at least one of the vulture’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-giant-vulture/multiattack]
+          {:id :creatures-giant-vulture/multiattack
+           :name "Multiattack"
+           :desc "The vulture makes two attacks: one with its beak and one with its talons."})
+        (provide-attr
+          [:attacks :creatures-giant-vulture/beak]
+          {:id :creatures-giant-vulture/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (2d4 + 2) piercing damage."
+           :damage :piercing
+           :dice "2d4+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-giant-vulture/talons]
+          {:id :creatures-giant-vulture/talons
+           :name "Talons"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _9 (2d6 + 2) slashing damage."
+           :damage :slashing
+           :dice "2d6+2"
+           :to-hit 4}))}
+  {:id :creatures/giant-wasp
+   :name "Giant Wasp"
+   :ac 12
+   :challenge 0.5
+   :hit-points "3d8"
+   :abilities {:str 10 :dex 14 :con 10 :int 1 :wis 10 :cha 3}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :beast
+   :speed "10 ft., fly 50 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-giant-wasp/sting]
+          {:id :creatures-giant-wasp/sting
+           :name "Sting"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _5 (1d6 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/giant-weasel
+   :name "Giant Weasel"
+   :ac 13
+   :challenge 0.125
+   :hit-points "2d8"
+   :abilities {:str 11 :dex 16 :con 10 :int 4 :wis 12 :cha 5}
+   :senses "darkvision 60 ft., passive Perception 13"
+   :size :medium
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-weasel/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-attr
+          [:attacks :creatures-giant-weasel/bite]
+          {:id :creatures-giant-weasel/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _5 (1d4 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d4+3"
+           :to-hit 5}))}
+  {:id :creatures/giant-wolf-spider
+   :name "Giant Wolf Spider"
+   :ac 13
+   :challenge 0.25
+   :hit-points "2d8 + 2"
+   :abilities {:str 12 :dex 16 :con 13 :int 3 :wis 12 :cha 4}
+   :senses "blindsight 10 ft., darkvision 60 ft., passive Perception 13"
+   :size :medium
+   :type :beast
+   :speed "40 ft., climb 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-giant-wolf-spider/spider-climb
+           :name "Spider Climb"
+           :desc "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."})
+        (provide-feature
+          {:id :creatures-giant-wolf-spider/web-sense
+           :name "Web Sense"
+           :desc "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."})
+        (provide-feature
+          {:id :creatures-giant-wolf-spider/web-walker
+           :name "Web Walker"
+           :desc "The spider ignores movement restrictions caused by webbing."})
+        (provide-attr
+          [:attacks :creatures-giant-wolf-spider/bite]
+          {:id :creatures-giant-wolf-spider/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one creature. _Hit: _4 (1d6 + 1) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 7 (2d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+           :damage :piercing
+           :dice "1d6+1"
+           :to-hit 3}))}
+  {:id :creatures/goat
+   :name "Goat"
+   :ac 10
+   :challenge 0
+   :hit-points "1d8"
+   :abilities {:str 12 :dex 10 :con 11 :int 2 :wis 10 :cha 5}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-goat/charge
+           :name "Charge"
+           :desc "If the goat moves at least 20 feet straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 2 (1d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 10 Strength saving throw or be knocked prone."})
+        (provide-feature
+          {:id :creatures-goat/sure-footed
+           :name "Sure-Footed"
+           :desc "The goat has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."})
+        (provide-attr
+          [:attacks :creatures-goat/ram]
+          {:id :creatures-goat/ram
+           :name "Ram"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _3 (1d4 + 1) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d4+1"
+           :to-hit 3}))}
+  {:id :creatures/hawk
+   :name "Hawk"
+   :ac 13
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 5 :dex 16 :con 8 :int 2 :wis 14 :cha 6}
+   :senses "passive Perception 14"
+   :size :tiny
+   :type :beast
+   :speed "10 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-hawk/keen-sight
+           :name "Keen Sight"
+           :desc "The hawk has advantage on Wisdom (Perception) checks that rely on sight."})
+        (provide-attr
+          [:attacks :creatures-hawk/talons]
+          {:id :creatures-hawk/talons
+           :name "Talons"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _1 slashing damage."
+           :to-hit 5}))}
+  {:id :creatures/hunter-shark
+   :name "Hunter Shark"
+   :ac 12
+   :challenge 2
+   :hit-points "6d10 + 12"
+   :abilities {:str 18 :dex 13 :con 15 :int 1 :wis 10 :cha 4}
+   :senses "blindsight 30 ft., passive Perception 12"
+   :size :large
+   :type :beast
+   :speed "0 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-hunter-shark/blood-frenzy
+           :name "Blood Frenzy"
+           :desc "The shark has advantage on melee attack rolls against any creature that doesn’t have all its hit points."})
+        (provide-feature
+          {:id :creatures-hunter-shark/water-breathing
+           :name "Water Breathing"
+           :desc "The shark can breathe only underwater."})
+        (provide-attr
+          [:attacks :creatures-hunter-shark/bite]
+          {:id :creatures-hunter-shark/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _13 (2d8 + 4) piercing damage."
+           :damage :piercing
+           :dice "2d8+4"
+           :to-hit 6}))}
+  {:id :creatures/hyena
+   :name "Hyena"
+   :ac 11
+   :challenge 0
+   :hit-points "1d8 + 1"
+   :abilities {:str 11 :dex 13 :con 12 :int 2 :wis 12 :cha 5}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-hyena/pack-tactics
+           :name "Pack Tactics"
+           :desc "The hyena has advantage on an attack roll against a creature if at least one of the hyena’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-hyena/bite]
+          {:id :creatures-hyena/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _3 (1d6) piercing damage."
+           :damage :piercing
+           :dice "1d6"
+           :to-hit 2}))}
+  {:id :creatures/jackal
+   :name "Jackal"
+   :ac 12
+   :challenge 0
+   :hit-points "1d6"
+   :abilities {:str 8 :dex 15 :con 11 :int 3 :wis 12 :cha 6}
+   :senses "passive Perception 13"
+   :size :small
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-jackal/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The jackal has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-feature
+          {:id :creatures-jackal/pack-tactics
+           :name "Pack Tactics"
+           :desc "The jackal has advantage on an attack roll against a creature if at least one of the jackal’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-jackal/bite]
+          {:id :creatures-jackal/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+1 to hit, reach 5 ft., one target. _Hit: _1 (1d4 – 1) piercing damage."
+           :to-hit 1}))}
+  {:id :creatures/killer-whale
+   :name "Killer Whale"
+   :ac 12
+   :challenge 3
+   :hit-points "12d12 + 12"
+   :abilities {:str 19 :dex 10 :con 13 :int 3 :wis 12 :cha 7}
+   :senses "blindsight 120 ft., passive Perception 13"
+   :size :huge
+   :type :beast
+   :speed "0 ft., swim 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-killer-whale/echolocation
+           :name "Echolocation"
+           :desc "The whale can’t use its blindsight while deafened."})
+        (provide-feature
+          {:id :creatures-killer-whale/hold-breath
+           :name "Hold Breath"
+           :desc "The whale can hold its breath for 30 minutes."})
+        (provide-feature
+          {:id :creatures-killer-whale/keen-hearing
+           :name "Keen Hearing"
+           :desc "The whale has advantage on Wisdom (Perception) checks that rely on hearing."})
+        (provide-attr
+          [:attacks :creatures-killer-whale/bite]
+          {:id :creatures-killer-whale/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _21 (5d6 + 4) piercing damage."
+           :damage :piercing
+           :dice "5d6+4"
+           :to-hit 6}))}
+  {:id :creatures/lion
+   :name "Lion"
+   :ac 12
+   :challenge 1
+   :hit-points "4d10 + 4"
+   :abilities {:str 17 :dex 15 :con 13 :int 3 :wis 12 :cha 8}
+   :senses "passive Perception 13"
+   :size :large
+   :type :beast
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-lion/keen-smell
+           :name "Keen Smell"
+           :desc "The lion has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-feature
+          {:id :creatures-lion/pack-tactics
+           :name "Pack Tactics"
+           :desc "The lion has advantage on an attack roll against a creature if at least one of the lion’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-feature
+          {:id :creatures-lion/pounce
+           :name "Pounce"
+           :desc "If the lion moves at least 20 feet straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the lion can make one bite attack against it as a bonus action."})
+        (provide-feature
+          {:id :creatures-lion/running-leap
+           :name "Running Leap"
+           :desc "With a 10-foot running start, the lion can long jump up to 25 feet."})
+        (provide-attr
+          [:attacks :creatures-lion/bite]
+          {:id :creatures-lion/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d8+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-lion/claw]
+          {:id :creatures-lion/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d6+3"
+           :to-hit 5}))}
+  {:id :creatures/lizard
+   :name "Lizard"
+   :ac 10
+   :challenge 0
+   :hit-points "1d4"
+   :abilities {:str 2 :dex 11 :con 10 :int 1 :wis 8 :cha 3}
+   :senses "darkvision 30 ft., passive Perception 9"
+   :size :tiny
+   :type :beast
+   :speed "20 ft., climb 20 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-lizard/bite]
+          {:id :creatures-lizard/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+0 to hit, reach 5 ft., one target. _Hit: _1 piercing damage."
+           :to-hit 0}))}
+  {:id :creatures/mammoth
+   :name "Mammoth"
+   :ac 13
+   :challenge 6
+   :hit-points "11d12 + 55"
+   :abilities {:str 24 :dex 9 :con 21 :int 3 :wis 11 :cha 6}
+   :senses "passive Perception 10"
+   :size :huge
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-mammoth/trampling-charge
+           :name "Trampling Charge"
+           :desc "If the mammoth moves at least 20 feet straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 18 Strength saving throw or be knocked prone. If the target is prone, the mammoth can make one stomp attack against it as a bonus action."})
+        (provide-attr
+          [:attacks :creatures-mammoth/gore]
+          {:id :creatures-mammoth/gore
+           :name "Gore"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 10 ft., one target. _Hit: _25 (4d8 + 7) piercing damage."
+           :damage :piercing
+           :dice "4d8+7"
+           :to-hit 10})
+        (provide-attr
+          [:attacks :creatures-mammoth/stomp]
+          {:id :creatures-mammoth/stomp
+           :name "Stomp"
+           :desc "_Melee Weapon Attack: _+10 to hit, reach 5 ft., one prone creature. _Hit: _29 (4d10 + 7) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "4d10+7"
+           :to-hit 10}))}
+  {:id :creatures/mastiff
+   :name "Mastiff"
+   :ac 12
+   :challenge 0.125
+   :hit-points "1d8 + 1"
+   :abilities {:str 13 :dex 14 :con 12 :int 3 :wis 12 :cha 7}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-mastiff/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The mastiff has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-attr
+          [:attacks :creatures-mastiff/bite]
+          {:id :creatures-mastiff/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+           :damage :piercing
+           :dice "1d6+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-mastiff/mastiffs
+           :name "Mastiffs"
+           :desc "are impressive hounds prized by humanoids for their loyalty and keen senses. Mastiffs can be trained as guard dogs, hunting dogs, and war dogs. Halflings and other Small humanoids ride them as mounts."}))}
+  {:id :creatures/mule
+   :name "Mule"
+   :ac 10
+   :challenge 0.125
+   :hit-points "2d8 + 2"
+   :abilities {:str 14 :dex 10 :con 13 :int 2 :wis 10 :cha 5}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-mule/beast-of-burden
+           :name "Beast of Burden"
+           :desc "The mule is considered to be a Large animal for the purpose of determining its carrying capacity."})
+        (provide-feature
+          {:id :creatures-mule/sure-footed
+           :name "Sure-Footed"
+           :desc "The mule has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."})
+        (provide-attr
+          [:attacks :creatures-mule/hooves]
+          {:id :creatures-mule/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _4 (1d4 + 2) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d4+2"
+           :to-hit 2}))}
+  {:id :creatures/octopus
+   :name "Octopus"
+   :ac 12
+   :challenge 0
+   :hit-points "1d6"
+   :abilities {:str 4 :dex 15 :con 11 :int 3 :wis 10 :cha 4}
+   :senses "darkvision 30 ft., passive Perception 12"
+   :size :small
+   :type :beast
+   :speed "5 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-octopus/hold-breath
+           :name "Hold Breath"
+           :desc "While out of water, the octopus can hold its breath for 30 minutes."})
+        (provide-feature
+          {:id :creatures-octopus/underwater-camouflage
+           :name "Underwater Camouflage"
+           :desc "The octopus has advantage on Dexterity (Stealth) checks made while underwater."})
+        (provide-feature
+          {:id :creatures-octopus/water-breathing
+           :name "Water Breathing"
+           :desc "The octopus can breathe only underwater."})
+        (provide-attr
+          [:attacks :creatures-octopus/tentacles]
+          {:id :creatures-octopus/tentacles
+           :name "Tentacles"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _1 bludgeoning damage, and the target is grappled (escape DC 10). Until this grapple ends, the octopus can’t use its tentacles on another target."
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-octopus/ink-cloud
+           :name "Ink Cloud (Recharges after a Short or Long Rest)"
+           :desc "A 5-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action."}))}
+  {:id :creatures/owl
+   :name "Owl"
+   :ac 11
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 3 :dex 13 :con 8 :int 2 :wis 12 :cha 7}
+   :senses "darkvision 120 ft., passive Perception 13"
+   :size :tiny
+   :type :beast
+   :speed "5 ft., fly 60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-owl/flyby
+           :name "Flyby"
+           :desc "The owl doesn’t provoke opportunity attacks when it flies out of an enemy’s reach."})
+        (provide-feature
+          {:id :creatures-owl/keen-hearing-and-sight
+           :name "Keen Hearing and Sight"
+           :desc "The owl has advantage on Wisdom (Perception) checks that rely on hearing or sight."})
+        (provide-attr
+          [:attacks :creatures-owl/talons]
+          {:id :creatures-owl/talons
+           :name "Talons"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _1 slashing damage."
+           :to-hit 3}))}
+  {:id :creatures/panther
+   :name "Panther"
+   :ac 12
+   :challenge 0.25
+   :hit-points "3d8"
+   :abilities {:str 14 :dex 15 :con 10 :int 3 :wis 14 :cha 7}
+   :senses "passive Perception 14"
+   :size :medium
+   :type :beast
+   :speed "50 ft., climb 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-panther/keen-smell
+           :name "Keen Smell"
+           :desc "The panther has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-feature
+          {:id :creatures-panther/pounce
+           :name "Pounce"
+           :desc "If the panther moves at least 20 feet straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 12 Strength saving throw or be knocked prone. If the target is prone, the panther can make one bite attack against it as a bonus action."})
+        (provide-attr
+          [:attacks :creatures-panther/bite]
+          {:id :creatures-panther/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-panther/claw]
+          {:id :creatures-panther/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _4 (1d4 + 2) slashing damage."
+           :damage :slashing
+           :dice "1d4+2"
+           :to-hit 4}))}
+  {:id :creatures/phase-spider
+   :name "Phase Spider"
+   :ac 13
+   :challenge 3
+   :hit-points "5d10 + 5"
+   :abilities {:str 15 :dex 15 :con 12 :int 6 :wis 10 :cha 6}
+   :senses "darkvision 60 ft., passive Perception 10"
+   :size :large
+   :type :monstrosity
+   :speed "30 ft., climb 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-phase-spider/ethereal-jaunt
+           :name "Ethereal Jaunt"
+           :desc "As a bonus action, the spider can magically shift from the Material Plane to the Ethereal Plane, or vice versa."})
+        (provide-feature
+          {:id :creatures-phase-spider/spider-climb
+           :name "Spider Climb"
+           :desc "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."})
+        (provide-feature
+          {:id :creatures-phase-spider/web-walker
+           :name "Web Walker"
+           :desc "The spider ignores movement restrictions caused by webbing."})
+        (provide-attr
+          [:attacks :creatures-phase-spider/bite]
+          {:id :creatures-phase-spider/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _7 (1d10 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 18 (4d8) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+           :damage :piercing
+           :dice "1d10+2"
+           :to-hit 4}))}
+  {:id :creatures/poisonous-snake
+   :name "Poisonous Snake"
+   :ac 13
+   :challenge 0.125
+   :hit-points "1d4"
+   :abilities {:str 2 :dex 16 :con 11 :int 1 :wis 10 :cha 3}
+   :senses "blindsight 10 ft., passive Perception 10"
+   :size :tiny
+   :type :beast
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-poisonous-snake/bite]
+          {:id :creatures-poisonous-snake/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _1 piercing damage, and the target must make a DC 10 Constitution saving throw, taking 5 (2d4) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :poison
+           :dice "2d4"
+           :to-hit 5}))}
+  {:id :creatures/polar-bear
+   :name "Polar Bear"
+   :ac 12
+   :challenge 2
+   :hit-points "5d10 + 15"
+   :abilities {:str 20 :dex 10 :con 16 :int 2 :wis 13 :cha 7}
+   :senses "passive Perception 13"
+   :size :large
+   :type :beast
+   :speed "40 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-polar-bear/keen-smell
+           :name "Keen Smell"
+           :desc "The bear has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-attr
+          [:attacks :creatures-polar-bear/multiattack]
+          {:id :creatures-polar-bear/multiattack
+           :name "Multiattack"
+           :desc "The bear makes two attacks: one with its bite and one with its claws."})
+        (provide-attr
+          [:attacks :creatures-polar-bear/bite]
+          {:id :creatures-polar-bear/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _9 (1d8 + 5) piercing damage."
+           :damage :piercing
+           :dice "1d8+5"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-polar-bear/claws]
+          {:id :creatures-polar-bear/claws
+           :name "Claws"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _12 (2d6 + 5) slashing damage."
+           :damage :slashing
+           :dice "2d6+5"
+           :to-hit 7}))}
+  {:id :creatures/pony
+   :name "Pony"
+   :ac 10
+   :challenge 0.125
+   :hit-points "2d8 + 2"
+   :abilities {:str 15 :dex 10 :con 13 :int 2 :wis 11 :cha 7}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-pony/hooves]
+          {:id :creatures-pony/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (2d4 + 2) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d4+2"
+           :to-hit 4}))}
+  {:id :creatures/quipper
+   :name "Quipper"
+   :ac 13
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 2 :dex 16 :con 9 :int 1 :wis 7 :cha 2}
+   :senses "darkvision 60 ft., passive Perception 8"
+   :size :tiny
+   :type :beast
+   :speed "0 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-quipper/blood-frenzy
+           :name "Blood Frenzy"
+           :desc "The quipper has advantage on melee attack rolls against any creature that doesn’t have all its hit points."})
+        (provide-feature
+          {:id :creatures-quipper/water-breathing
+           :name "Water Breathing"
+           :desc "The quipper can breathe only underwater."})
+        (provide-attr
+          [:attacks :creatures-quipper/bite]
+          {:id :creatures-quipper/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _1 piercing damage."
+           :to-hit 5}))}
+  {:id :creatures/rat
+   :name "Rat"
+   :ac 10
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 2 :dex 11 :con 9 :int 2 :wis 10 :cha 4}
+   :senses "darkvision 30 ft., passive Perception 10"
+   :size :tiny
+   :type :beast
+   :speed "20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-rat/keen-smell
+           :name "Keen Smell"
+           :desc "The rat has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-attr
+          [:attacks :creatures-rat/bite]
+          {:id :creatures-rat/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+0 to hit, reach 5 ft., one target. _Hit: _1 piercing damage."
+           :to-hit 0}))}
+  {:id :creatures/raven
+   :name "Raven"
+   :ac 12
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 2 :dex 14 :con 8 :int 2 :wis 12 :cha 6}
+   :senses "passive Perception 13"
+   :size :tiny
+   :type :beast
+   :speed "10 ft., fly 50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-raven/mimicry
+           :name "Mimicry"
+           :desc "The raven can mimic simple sounds it has heard, such as a person whispering, a baby crying, or an animal chittering. A creature that hears the sounds can tell they are imitations with a successful DC 10 Wisdom (Insight) check."})
+        (provide-attr
+          [:attacks :creatures-raven/beak]
+          {:id :creatures-raven/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _1 piercing damage."
+           :to-hit 4}))}
+  {:id :creatures/reef-shark
+   :name "Reef Shark"
+   :ac 12
+   :challenge 0.5
+   :hit-points "4d8 + 4"
+   :abilities {:str 14 :dex 13 :con 13 :int 1 :wis 10 :cha 4}
+   :senses "blindsight 30 ft., passive Perception 12"
+   :size :medium
+   :type :beast
+   :speed "0 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-reef-shark/pack-tactics
+           :name "Pack Tactics"
+           :desc "The shark has advantage on an attack roll against a creature if at least one of the shark’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-feature
+          {:id :creatures-reef-shark/water-breathing
+           :name "Water Breathing"
+           :desc "The shark can breathe only underwater."})
+        (provide-attr
+          [:attacks :creatures-reef-shark/bite]
+          {:id :creatures-reef-shark/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _6 (1d8 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 4}))}
+  {:id :creatures/rhinoceros
+   :name "Rhinoceros"
+   :ac 11
+   :challenge 2
+   :hit-points "6d10 + 12"
+   :abilities {:str 21 :dex 8 :con 15 :int 2 :wis 12 :cha 6}
+   :senses "passive Perception 11"
+   :size :large
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-rhinoceros/charge
+           :name "Charge"
+           :desc "If the rhinoceros moves at least 20 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) bludgeoning damage. If the target is a creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."})
+        (provide-attr
+          [:attacks :creatures-rhinoceros/gore]
+          {:id :creatures-rhinoceros/gore
+           :name "Gore"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one target. _Hit: _14 (2d8 + 5) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d8+5"
+           :to-hit 7}))}
+  {:id :creatures/riding-horse
+   :name "Riding Horse"
+   :ac 10
+   :challenge 0.25
+   :hit-points "2d10 + 2"
+   :abilities {:str 16 :dex 10 :con 12 :int 2 :wis 11 :cha 7}
+   :senses "passive Perception 10"
+   :size :large
+   :type :beast
+   :speed "60 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-riding-horse/hooves]
+          {:id :creatures-riding-horse/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _8 (2d4 + 3) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d4+3"
+           :to-hit 5}))}
+  {:id :creatures/saber-toothed-tiger
+   :name "Saber-Toothed Tiger"
+   :ac 12
+   :challenge 2
+   :hit-points "7d10 + 14"
+   :abilities {:str 18 :dex 14 :con 15 :int 3 :wis 12 :cha 8}
+   :senses "passive Perception 13"
+   :size :large
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-saber-toothed-tiger/keen-smell
+           :name "Keen Smell"
+           :desc "The tiger has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-feature
+          {:id :creatures-saber-toothed-tiger/pounce
+           :name "Pounce"
+           :desc "If the tiger moves at least 20 feet straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the tiger can make one bite attack against it as a bonus action."})
+        (provide-attr
+          [:attacks :creatures-saber-toothed-tiger/bite]
+          {:id :creatures-saber-toothed-tiger/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _10 (1d10 + 5) piercing damage."
+           :damage :piercing
+           :dice "1d10+5"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-saber-toothed-tiger/claw]
+          {:id :creatures-saber-toothed-tiger/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _12 (2d6 + 5) slashing damage."
+           :damage :slashing
+           :dice "2d6+5"
+           :to-hit 6}))}
+  {:id :creatures/scorpion
+   :name "Scorpion"
+   :ac 11
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 2 :dex 11 :con 8 :int 1 :wis 8 :cha 2}
+   :senses "blindsight 10 ft., passive Perception 9"
+   :size :tiny
+   :type :beast
+   :speed "10 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-scorpion/sting]
+          {:id :creatures-scorpion/sting
+           :name "Sting"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one creature. _Hit: _1 piercing damage, and the target must make a DC 9 Constitution saving throw, taking 4 (1d8) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :poison
+           :dice "1d8"
+           :to-hit 2}))}
+  {:id :creatures/sea-horse
+   :name "Sea Horse"
+   :ac 11
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 1 :dex 12 :con 8 :int 1 :wis 10 :cha 2}
+   :senses "passive Perception 10"
+   :size :tiny
+   :type :beast
+   :speed "0 ft., swim 20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-sea-horse/water-breathing
+           :name "Water Breathing"
+           :desc "The sea horse can breathe only underwater."}))}
+  {:id :creatures/spider
+   :name "Spider"
+   :ac 12
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 2 :dex 14 :con 8 :int 1 :wis 10 :cha 2}
+   :senses "darkvision 30 ft., passive Perception 10"
+   :size :tiny
+   :type :beast
+   :speed "20 ft., climb 20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-spider/spider-climb
+           :name "Spider Climb"
+           :desc "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."})
+        (provide-feature
+          {:id :creatures-spider/web-sense
+           :name "Web Sense"
+           :desc "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."})
+        (provide-feature
+          {:id :creatures-spider/web-walker
+           :name "Web Walker"
+           :desc "The spider ignores movement restrictions caused by webbing."})
+        (provide-attr
+          [:attacks :creatures-spider/bite]
+          {:id :creatures-spider/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _1 piercing damage, and the target must succeed on a DC 9 Constitution saving throw or take 2 (1d4) poison damage."
+           :damage :poison
+           :dice "1d4"
+           :to-hit 4}))}
+  {:id :creatures/swarm-of-bats
+   :name "Swarm of Bats"
+   :ac 12
+   :challenge 0.25
+   :hit-points "5d8"
+   :abilities {:str 5 :dex 15 :con 10 :int 2 :wis 12 :cha 4}
+   :senses "blindsight 60 ft., passive Perception 11"
+   :size :medium
+   :type :swarm
+   :speed "0 ft., fly 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-swarm-of-bats/echolocation
+           :name "Echolocation"
+           :desc "The swarm can’t use its blindsight while deafened."})
+        (provide-feature
+          {:id :creatures-swarm-of-bats/keen-hearing
+           :name "Keen Hearing"
+           :desc "The swarm has advantage on Wisdom (Perception) checks that rely on hearing."})
+        (provide-feature
+          {:id :creatures-swarm-of-bats/swarm
+           :name "Swarm"
+           :desc "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny bat. The swarm can’t regain hit points or gain temporary hit points."})
+        (provide-attr
+          [:attacks :creatures-swarm-of-bats/bites]
+          {:id :creatures-swarm-of-bats/bites
+           :name "Bites"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 0 ft., one creature in the swarm’s space. _Hit: _5 (2d4) piercing damage, or 2 (1d4) piercing damage if the swarm has half of its hit points or fewer."
+           :damage :piercing
+           :dice "2d4"
+           :to-hit 4}))}
+  {:id :creatures/swarm-of-insects
+   :name "Swarm of Insects"
+   :ac 12
+   :challenge 0.5
+   :hit-points "5d8"
+   :abilities {:str 3 :dex 13 :con 10 :int 1 :wis 7 :cha 1}
+   :senses "blindsight 10 ft., passive Perception 8"
+   :size :medium
+   :type :swarm
+   :speed "20 ft., climb 20 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-swarm-of-insects/swarm
+           :name "Swarm"
+           :desc "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can’t regain hit points or gain temporary hit points."})
+        (provide-attr
+          [:attacks :creatures-swarm-of-insects/bites]
+          {:id :creatures-swarm-of-insects/bites
+           :name "Bites"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 0 ft., one target in the swarm’s space. _Hit: _10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer."
+           :damage :piercing
+           :dice "4d4"
+           :to-hit 3}))}
+  {:id :creatures/swarm-of-poisonous-snakes
+   :name "Swarm of Poisonous Snakes"
+   :ac 14
+   :challenge 2
+   :hit-points "8d8"
+   :abilities {:str 8 :dex 18 :con 11 :int 1 :wis 10 :cha 3}
+   :senses "blindsight 10 ft., passive Perception 10"
+   :size :medium
+   :type :swarm
+   :speed "30 ft., swim 30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-swarm-of-poisonous-snakes/swarm
+           :name "Swarm"
+           :desc "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny snake. The swarm can’t regain hit points or gain temporary hit points."})
+        (provide-attr
+          [:attacks :creatures-swarm-of-poisonous-snakes/bites]
+          {:id :creatures-swarm-of-poisonous-snakes/bites
+           :name "Bites"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 0 ft., one creature in the swarm’s space. _Hit: _7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer. The target must make a DC 10 Constitution saving throw, taking 14 (4d6) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :piercing
+           :dice "2d6"
+           :to-hit 6}))}
+  {:id :creatures/swarm-of-quippers
+   :name "Swarm of Quippers"
+   :ac 13
+   :challenge 1
+   :hit-points "8d8 − 8"
+   :abilities {:str 13 :dex 16 :con 9 :int 1 :wis 7 :cha 2}
+   :senses "darkvision 60 ft., passive Perception 8"
+   :size :medium
+   :type :swarm
+   :speed "0 ft., swim 40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-swarm-of-quippers/blood-frenzy
+           :name "Blood Frenzy"
+           :desc "The swarm has advantage on melee attack rolls against any creature that doesn’t have all its hit points."})
+        (provide-feature
+          {:id :creatures-swarm-of-quippers/swarm
+           :name "Swarm"
+           :desc "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny quipper. The swarm can’t regain hit points or gain temporary hit points."})
+        (provide-feature
+          {:id :creatures-swarm-of-quippers/water-breathing
+           :name "Water Breathing"
+           :desc "The swarm can breathe only underwater."})
+        (provide-attr
+          [:attacks :creatures-swarm-of-quippers/bites]
+          {:id :creatures-swarm-of-quippers/bites
+           :name "Bites"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 0 ft., one creature in the swarm’s space. _Hit: _14 (4d6) piercing damage, or 7 (2d6) piercing damage if the swarm has half of its hit points or fewer."
+           :damage :piercing
+           :dice "4d6"
+           :to-hit 5}))}
+  {:id :creatures/swarm-of-rats
+   :name "Swarm of Rats"
+   :ac 10
+   :challenge 0.25
+   :hit-points "7d8 − 7"
+   :abilities {:str 9 :dex 11 :con 9 :int 2 :wis 10 :cha 3}
+   :senses "darkvision 30 ft., passive Perception 10"
+   :size :medium
+   :type :swarm
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-swarm-of-rats/keen-smell
+           :name "Keen Smell"
+           :desc "The swarm has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-feature
+          {:id :creatures-swarm-of-rats/swarm
+           :name "Swarm"
+           :desc "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny rat. The swarm can’t regain hit points or gain temporary hit points."})
+        (provide-attr
+          [:attacks :creatures-swarm-of-rats/bites]
+          {:id :creatures-swarm-of-rats/bites
+           :name "Bites"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 0 ft., one target in the swarm’s space. _Hit: _7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer."
+           :damage :piercing
+           :dice "2d6"
+           :to-hit 2}))}
+  {:id :creatures/swarm-of-ravens
+   :name "Swarm of Ravens"
+   :ac 12
+   :challenge 0.25
+   :hit-points "7d8 − 7"
+   :abilities {:str 6 :dex 14 :con 8 :int 3 :wis 12 :cha 6}
+   :senses "passive Perception 15"
+   :size :medium
+   :type :swarm
+   :speed "10 ft., fly 50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-swarm-of-ravens/swarm
+           :name "Swarm"
+           :desc "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny raven. The swarm can’t regain hit points or gain temporary hit points."})
+        (provide-attr
+          [:attacks :creatures-swarm-of-ravens/beaks]
+          {:id :creatures-swarm-of-ravens/beaks
+           :name "Beaks"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target in the swarm’s space. _Hit: _7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer."
+           :damage :piercing
+           :dice "2d6"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-swarm-of-ravens/variant-insect-swarms
+           :name "Variant: Insect Swarms"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-swarm-of-ravens/swarm-of-beetles
+           :name "Swarm of Beetles"
+           :desc "A swarm of beetles gains a burrowing speed of 5 feet."})
+        (provide-feature
+          {:id :creatures-swarm-of-ravens/swarm-of-centipedes
+           :name "Swarm of Centipedes"
+           :desc "A creature reduced to 0 hit points by a swarm of centipedes is stable but poisoned for 1 hour, even after regaining hit points, and paralyzed while poisoned in this way."})
+        (provide-feature
+          {:id :creatures-swarm-of-ravens/swarm-of-spiders
+           :name "Swarm of Spiders"
+           :desc "A swarm of spiders has the following additional traits."})
+        (provide-feature
+          {:id :creatures-swarm-of-ravens/swarm-of-wasps
+           :name "Swarm of Wasps"
+           :desc "A swarm of wasps has a walking speed of 5 feet, a flying speed of 30 feet, and no climbing speed."}))}
+  {:id :creatures/tiger
+   :name "Tiger"
+   :ac 12
+   :challenge 1
+   :hit-points "5d10 + 10"
+   :abilities {:str 17 :dex 15 :con 14 :int 3 :wis 12 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 13"
+   :size :large
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-tiger/keen-smell
+           :name "Keen Smell"
+           :desc "The tiger has advantage on Wisdom (Perception) checks that rely on smell."})
+        (provide-feature
+          {:id :creatures-tiger/pounce
+           :name "Pounce"
+           :desc "If the tiger moves at least 20 feet straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the tiger can make one bite attack against it as a bonus action."})
+        (provide-attr
+          [:attacks :creatures-tiger/bite]
+          {:id :creatures-tiger/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _8 (1d10 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d10+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-tiger/claw]
+          {:id :creatures-tiger/claw
+           :name "Claw"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d8+3"
+           :to-hit 5}))}
+  {:id :creatures/vulture
+   :name "Vulture"
+   :ac 10
+   :challenge 0
+   :hit-points "1d8 + 1"
+   :abilities {:str 7 :dex 10 :con 13 :int 2 :wis 12 :cha 4}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :beast
+   :speed "10 ft., fly 50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-vulture/keen-sight-and-smell
+           :name "Keen Sight and Smell"
+           :desc "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."})
+        (provide-feature
+          {:id :creatures-vulture/pack-tactics
+           :name "Pack Tactics"
+           :desc "The vulture has advantage on an attack roll against a creature if at least one of the vulture’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-vulture/beak]
+          {:id :creatures-vulture/beak
+           :name "Beak"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _2 (1d4) piercing damage."
+           :damage :piercing
+           :dice "1d4"
+           :to-hit 2}))}
+  {:id :creatures/warhorse
+   :name "Warhorse"
+   :ac 11
+   :challenge 0.5
+   :hit-points "3d10 + 3"
+   :abilities {:str 18 :dex 12 :con 13 :int 2 :wis 12 :cha 7}
+   :senses "passive Perception 11"
+   :size :large
+   :type :beast
+   :speed "60 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-warhorse/trampling-charge
+           :name "Trampling Charge"
+           :desc "If the horse moves at least 20 feet straight toward a creature and then hits it with a hooves attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the horse can make another attack with its hooves against it as a bonus action."})
+        (provide-attr
+          [:attacks :creatures-warhorse/hooves]
+          {:id :creatures-warhorse/hooves
+           :name "Hooves"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "2d6+4"
+           :to-hit 6}))}
+  {:id :creatures/weasel
+   :name "Weasel"
+   :ac 13
+   :challenge 0
+   :hit-points "1d4 − 1"
+   :abilities {:str 3 :dex 16 :con 8 :int 2 :wis 12 :cha 3}
+   :senses "passive Perception 13"
+   :size :tiny
+   :type :beast
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-weasel/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-attr
+          [:attacks :creatures-weasel/bite]
+          {:id :creatures-weasel/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _1 piercing damage."
+           :to-hit 5}))}
+  {:id :creatures/winter-wolf
+   :name "Winter Wolf"
+   :ac 13
+   :challenge 3
+   :hit-points "10d10 + 20"
+   :abilities {:str 18 :dex 13 :con 14 :int 7 :wis 12 :cha 8}
+   :senses "passive Perception 15"
+   :size :large
+   :type :monstrosity
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-winter-wolf/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-feature
+          {:id :creatures-winter-wolf/pack-tactics
+           :name "Pack Tactics"
+           :desc "The wolf has advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-feature
+          {:id :creatures-winter-wolf/snow-camouflage
+           :name "Snow Camouflage"
+           :desc "The wolf has advantage on Dexterity (Stealth) checks made to hide in snowy terrain."})
+        (provide-attr
+          [:attacks :creatures-winter-wolf/bite]
+          {:id :creatures-winter-wolf/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _11 (2d6 + 4) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
+           :damage :piercing
+           :dice "2d6+4"
+           :to-hit 6})
+        (provide-feature
+          {:id :creatures-winter-wolf/cold-breath
+           :name "Cold Breath (Recharge 5–6)"
+           :desc "The wolf exhales a blast of freezing wind in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 18 (4d8) cold damage on a failed save, or half as much damage on a successful one."}))}
+  {:id :creatures/wolf
+   :name "Wolf"
+   :ac 13
+   :challenge 0.25
+   :hit-points "2d8 + 2"
+   :abilities {:str 12 :dex 15 :con 12 :int 3 :wis 12 :cha 6}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :beast
+   :speed "40 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-wolf/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-feature
+          {:id :creatures-wolf/pack-tactics
+           :name "Pack Tactics"
+           :desc "The wolf has advantage on attack rolls against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-wolf/bite]
+          {:id :creatures-wolf/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _7 (2d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+           :damage :piercing
+           :dice "2d4+2"
+           :to-hit 4}))}
+  {:id :creatures/worg
+   :name "Worg"
+   :ac 13
+   :challenge 0.5
+   :hit-points "4d10 + 4"
+   :abilities {:str 16 :dex 13 :con 13 :int 7 :wis 11 :cha 8}
+   :senses "darkvision 60 ft., passive Perception 14"
+   :size :large
+   :type :monstrosity
+   :speed "50 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-worg/keen-hearing-and-smell
+           :name "Keen Hearing and Smell"
+           :desc "The worg has advantage on Wisdom (Perception) checks that rely on hearing or smell."})
+        (provide-attr
+          [:attacks :creatures-worg/bite]
+          {:id :creatures-worg/bite
+           :name "Bite"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+           :damage :piercing
+           :dice "2d6+3"
+           :to-hit 5}))}
+  {:id :creatures/acolyte
+   :name "Acolyte"
+   :ac 10
+   :challenge 0.25
+   :hit-points "2d8"
+   :abilities {:str 10 :dex 10 :con 10 :int 10 :wis 14 :cha 11}
+   :senses "passive Perception 12"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-acolyte/spellcasting
+           :name "Spellcasting"
+           :desc "The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The acolyte has following cleric spells prepared:"})
+        (provide-attr
+          [:attacks :creatures-acolyte/club]
+          {:id :creatures-acolyte/club
+           :name "Club"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _2 (1d4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d4"
+           :to-hit 2})
+        (provide-feature
+          {:id :creatures-acolyte/acolytes
+           :name "Acolytes"
+           :desc "are junior members of a clergy, usually answerable to a priest. They perform a variety of functions in a temple and are granted minor spellcasting power by their deities."}))}
+  {:id :creatures/assassin
+   :name "Assassin"
+   :ac 15
+   :challenge 8
+   :hit-points "12d8 + 24"
+   :abilities {:str 11 :dex 16 :con 14 :int 13 :wis 11 :cha 10}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-assassin/assassinate
+           :name "Assassinate"
+           :desc "During its first turn, the assassin has advantage on attack rolls against any creature that hasn’t taken a turn. Any hit the assassin scores against a surprised creature is a critical hit."})
+        (provide-feature
+          {:id :creatures-assassin/evasion
+           :name "Evasion"
+           :desc "If the assassin is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the assassin instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."})
+        (provide-feature
+          {:id :creatures-assassin/sneak-attack
+           :name "Sneak Attack"
+           :desc "Once per turn, the assassin deals an extra 14 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 feet of an ally of the assassin that isn’t incapacitated and the assassin doesn’t have disadvantage on the attack roll."})
+        (provide-attr
+          [:attacks :creatures-assassin/multiattack]
+          {:id :creatures-assassin/multiattack
+           :name "Multiattack"
+           :desc "The assassin makes two shortsword attacks."})
+        (provide-attr
+          [:attacks :creatures-assassin/shortsword]
+          {:id :creatures-assassin/shortsword
+           :name "Shortsword"
+           :desc "_Melee Weapon Attack: _+6 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :piercing
+           :dice "1d6+3"
+           :to-hit 6})
+        (provide-attr
+          [:attacks :creatures-assassin/light-crossbow]
+          {:id :creatures-assassin/light-crossbow
+           :name "Light Crossbow"
+           :desc "_Ranged Weapon Attack: _+6 to hit, range 80/320 ft., one target. _Hit: _7 (1d8 + 3) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one."
+           :damage :piercing
+           :dice "1d8+3"
+           :to-hit 6}))}
+  {:id :creatures/bandit
+   :name "Bandit"
+   :ac 12
+   :challenge 0.125
+   :hit-points "2d8 + 2"
+   :abilities {:str 11 :dex 12 :con 12 :int 10 :wis 10 :cha 10}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-bandit/scimitar]
+          {:id :creatures-bandit/scimitar
+           :name "Scimitar"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _4 (1d6 + 1) slashing damage."
+           :damage :slashing
+           :dice "1d6+1"
+           :to-hit 3})
+        (provide-attr
+          [:attacks :creatures-bandit/light-crossbow]
+          {:id :creatures-bandit/light-crossbow
+           :name "Light Crossbow"
+           :desc "_Ranged Weapon Attack: _+3 to hit, range 80 ft./320 ft., one target. _Hit: _5 (1d8 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d8+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-bandit/bandits
+           :name "Bandits"
+           :desc "rove in gangs and are sometimes led by thugs, veterans, or spellcasters. Not all bandits are evil. Oppression, drought, disease, or famine can often drive otherwise honest folk to a life of banditry."})
+        (provide-feature
+          {:id :creatures-bandit/pirates
+           :name "Pirates"
+           :desc "are bandits of the high seas. They might be freebooters interested only in treasure and murder, or they might be privateers sanctioned by the crown to attack and plunder an enemy nation’s vessels."}))}
+  {:id :creatures/bandit-captain
+   :name "Bandit Captain"
+   :ac 15
+   :challenge 2
+   :hit-points "10d8 + 20"
+   :abilities {:str 15 :dex 16 :con 14 :int 14 :wis 11 :cha 14}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-bandit-captain/multiattack]
+          {:id :creatures-bandit-captain/multiattack
+           :name "Multiattack"
+           :desc "The captain makes three melee attacks: two with its scimitar and one with its dagger. Or the captain makes two ranged attacks with its daggers."})
+        (provide-attr
+          [:attacks :creatures-bandit-captain/scimitar]
+          {:id :creatures-bandit-captain/scimitar
+           :name "Scimitar"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-bandit-captain/dagger]
+          {:id :creatures-bandit-captain/dagger
+           :name "Dagger"
+           :desc "_Melee or Ranged Weapon Attack: _+5 to hit, reach 5 ft. or range 20/60 ft., one target. _Hit: _5 (1d4 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d4+3"
+           :to-hit 5})
+        (provide-feature
+          {:id :creatures-bandit-captain/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-bandit-captain/parry
+           :name "Parry"
+           :desc "The captain adds 2 to its AC against one melee attack that would hit it. To do so, the captain must see the attacker and be wielding a melee weapon."}))}
+  {:id :creatures/berserker
+   :name "Berserker"
+   :ac 13
+   :challenge 2
+   :hit-points "9d8 + 27"
+   :abilities {:str 16 :dex 12 :con 17 :int 9 :wis 11 :cha 9}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-berserker/reckless
+           :name "Reckless"
+           :desc "At the start of its turn, the berserker can gain advantage on all melee weapon attack rolls during that turn, but attack rolls against it have advantage until the start of its next turn."})
+        (provide-attr
+          [:attacks :creatures-berserker/greataxe]
+          {:id :creatures-berserker/greataxe
+           :name "Greataxe"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _9 (1d12 + 3) slashing damage."
+           :damage :slashing
+           :dice "1d12+3"
+           :to-hit 5}))}
+  {:id :creatures/commoner
+   :name "Commoner"
+   :ac 10
+   :challenge 0
+   :hit-points "1d8"
+   :abilities {:str 10 :dex 10 :con 10 :int 10 :wis 10 :cha 10}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-commoner/club]
+          {:id :creatures-commoner/club
+           :name "Club"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _2 (1d4) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d4"
+           :to-hit 2})
+        (provide-feature
+          {:id :creatures-commoner/commoners
+           :name "Commoners"
+           :desc "include peasants, serfs, slaves, servants, pilgrims, merchants, artisans, and hermits."}))}
+  {:id :creatures/cultist
+   :name "Cultist"
+   :ac 12
+   :challenge 0.125
+   :hit-points "2d8"
+   :abilities {:str 11 :dex 12 :con 10 :int 10 :wis 11 :cha 10}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-cultist/dark-devotion
+           :name "Dark Devotion"
+           :desc "The cultist has advantage on saving throws against being charmed or frightened."})
+        (provide-attr
+          [:attacks :creatures-cultist/scimitar]
+          {:id :creatures-cultist/scimitar
+           :name "Scimitar"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one creature. _Hit: _4 (1d6 + 1) slashing damage."
+           :damage :slashing
+           :dice "1d6+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-cultist/cultists
+           :name "Cultists"
+           :desc "swear allegiance to dark powers such as elemental princes, demon lords, or archdevils. Most conceal their loyalties to avoid being ostracized, imprisoned, or executed for their beliefs. Unlike evil acolytes, cultists often show signs of insanity in their beliefs and practices."}))}
+  {:id :creatures/cult-fanatic
+   :name "Cult Fanatic"
+   :ac 13
+   :challenge 2
+   :hit-points "6d8 + 6"
+   :abilities {:str 11 :dex 14 :con 12 :int 10 :wis 13 :cha 14}
+   :senses "passive Perception 11"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-cult-fanatic/dark-devotion
+           :name "Dark Devotion"
+           :desc "The fanatic has advantage on saving throws against being charmed or frightened."})
+        (provide-feature
+          {:id :creatures-cult-fanatic/spellcasting
+           :name "Spellcasting"
+           :desc "The fanatic is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 11, +3 to hit with spell attacks). The fanatic has the following cleric spells prepared:"})
+        (provide-attr
+          [:attacks :creatures-cult-fanatic/multiattack]
+          {:id :creatures-cult-fanatic/multiattack
+           :name "Multiattack"
+           :desc "The fanatic makes two melee attacks."})
+        (provide-attr
+          [:attacks :creatures-cult-fanatic/dagger]
+          {:id :creatures-cult-fanatic/dagger
+           :name "Dagger"
+           :desc "_Melee or Ranged Weapon Attack: _+4 to hit, reach 5 ft. or range 20/60 ft., one creature. _Hit:_ 4 (1d4 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d4+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-cult-fanatic/fanatics
+           :name "Fanatics"
+           :desc "are often part of a cult’s leadership, using their charisma and dogma to influence and prey on those of weak will. Most are interested in personal power above all else."}))}
+  {:id :creatures/gladiator
+   :name "Gladiator"
+   :ac 16
+   :challenge 5
+   :hit-points "15d8 + 45"
+   :abilities {:str 18 :dex 15 :con 16 :int 10 :wis 12 :cha 15}
+   :senses "passive Perception 11"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-gladiator/brave
+           :name "Brave"
+           :desc "The gladiator has advantage on saving throws against being frightened."})
+        (provide-feature
+          {:id :creatures-gladiator/brute
+           :name "Brute"
+           :desc "A melee weapon deals one extra die of its damage when the gladiator hits with it (included in the attack)."})
+        (provide-attr
+          [:attacks :creatures-gladiator/multiattack]
+          {:id :creatures-gladiator/multiattack
+           :name "Multiattack"
+           :desc "The gladiator makes three melee attacks or two ranged attacks."})
+        (provide-attr
+          [:attacks :creatures-gladiator/spear]
+          {:id :creatures-gladiator/spear
+           :name "Spear"
+           :desc "_Melee or Ranged Weapon Attack: _+7 to hit, reach 5 ft. and range 20/60 ft., one target. _Hit: _11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack."
+           :damage :piercing
+           :dice "2d6+4"
+           :to-hit 7})
+        (provide-attr
+          [:attacks :creatures-gladiator/shield-bash]
+          {:id :creatures-gladiator/shield-bash
+           :name "Shield Bash"
+           :desc "_Melee Weapon Attack: _+7 to hit, reach 5 ft., one creature. _Hit: _9 (2d4 + 4) bludgeoning damage. If the target is a Medium or smaller creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+           :damage :bludgeoning
+           :dice "2d4+4"
+           :to-hit 7})
+        (provide-feature
+          {:id :creatures-gladiator/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-gladiator/parry
+           :name "Parry"
+           :desc "The gladiator adds 3 to its AC against one melee attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon."})
+        (provide-feature
+          {:id :creatures-gladiator/gladiators
+           :name "Gladiators"
+           :desc "battle for the entertainment of raucous crowds. Some gladiators are brutal pit fighters who treat each match as a life-or-death struggle, while others are professional duelists who command huge fees but rarely fight to the death."}))}
+  {:id :creatures/guard
+   :name "Guard"
+   :ac 16
+   :challenge 0.125
+   :hit-points "2d8 + 2"
+   :abilities {:str 13 :dex 12 :con 12 :int 10 :wis 11 :cha 10}
+   :senses "passive Perception 12"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-guard/spear]
+          {:id :creatures-guard/spear
+           :name "Spear"
+           :desc "_Melee or Ranged Weapon Attack: _+3 to hit, reach 5 ft. or range 20/60 ft., one target. _Hit: _4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack."
+           :damage :piercing
+           :dice "1d6+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-guard/guards
+           :name "Guards"
+           :desc "include members of a city watch, sentries in a citadel or fortified town, and the bodyguards of merchants and nobles."}))}
+  {:id :creatures/knight
+   :name "Knight"
+   :ac 18
+   :challenge 3
+   :hit-points "8d8 + 16"
+   :abilities {:str 16 :dex 11 :con 14 :int 11 :wis 11 :cha 15}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-knight/brave
+           :name "Brave"
+           :desc "The knight has advantage on saving throws against being frightened."})
+        (provide-attr
+          [:attacks :creatures-knight/multiattack]
+          {:id :creatures-knight/multiattack
+           :name "Multiattack"
+           :desc "The knight makes two melee attacks."})
+        (provide-attr
+          [:attacks :creatures-knight/greatsword]
+          {:id :creatures-knight/greatsword
+           :name "Greatsword"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _10 (2d6 + 3) slashing damage."
+           :damage :slashing
+           :dice "2d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-knight/heavy-crossbow]
+          {:id :creatures-knight/heavy-crossbow
+           :name "Heavy Crossbow"
+           :desc "_Ranged Weapon Attack: _+2 to hit, range 100/400 ft., one target. _Hit: _5 (1d10) piercing damage."
+           :damage :piercing
+           :dice "1d10"
+           :to-hit 2})
+        (provide-feature
+          {:id :creatures-knight/leadership
+           :name "Leadership (Recharges after a Short or Long Rest)"
+           :desc "For 1 minute, the knight can utter a special command or warning whenever a nonhostile creature that it can see within 30 feet of it makes an attack roll or a saving throw. The creature can add a d4 to its roll provided it can hear and understand the knight. A creature can benefit from only one Leadership die at a time. This effect ends if the knight is incapacitated."})
+        (provide-feature
+          {:id :creatures-knight/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-knight/parry
+           :name "Parry"
+           :desc "The knight adds 2 to its AC against one melee attack that would hit it. To do so, the knight must see the attacker and be wielding a melee weapon."})
+        (provide-feature
+          {:id :creatures-knight/knights
+           :name "Knights"
+           :desc "are warriors who pledge service to rulers, religious orders, and noble causes. A knight’s alignment determines the extent to which a pledge is honored. Whether undertaking a quest or patrolling a realm, a knight often travels with an entourage that includes squires and hirelings who are commoners."}))}
+  {:id :creatures/noble
+   :name "Noble"
+   :ac 15
+   :challenge 0.125
+   :hit-points "2d8"
+   :abilities {:str 11 :dex 12 :con 11 :int 12 :wis 14 :cha 16}
+   :senses "passive Perception 12"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-noble/rapier]
+          {:id :creatures-noble/rapier
+           :name "Rapier"
+           :desc "_Melee Weapon Attack: _+3 to hit, reach 5 ft., one target. _Hit: _5 (1d8 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d8+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-noble/reactions
+           :name "Reactions"
+           :desc ""})
+        (provide-feature
+          {:id :creatures-noble/parry
+           :name "Parry"
+           :desc "The noble adds 2 to its AC against one melee attack that would hit it. To do so, the noble must see the attacker and be wielding a melee weapon."})
+        (provide-feature
+          {:id :creatures-noble/nobles
+           :name "Nobles"
+           :desc "wield great authority and influence as members of the upper class, possessing wealth and connections that can make them as powerful as monarchs and generals. A noble often travels in the company of guards, as well as servants who are commoners."}))}
+  {:id :creatures/priest
+   :name "Priest"
+   :ac 13
+   :challenge 2
+   :hit-points "5d8 + 5"
+   :abilities {:str 10 :dex 10 :con 12 :int 13 :wis 16 :cha 13}
+   :senses "passive Perception 13"
+   :size :medium
+   :type :humanoid
+   :speed "25 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-priest/divine-eminence
+           :name "Divine Eminence"
+           :desc "As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra 10 (3d6) radiant damage to a target on a hit. This benefit lasts until the end of the turn. If the priest expends a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each level above 1st."})
+        (provide-feature
+          {:id :creatures-priest/spellcasting
+           :name "Spellcasting"
+           :desc "The priest is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priest has the following cleric spells prepared:"})
+        (provide-attr
+          [:attacks :creatures-priest/mace]
+          {:id :creatures-priest/mace
+           :name "Mace"
+           :desc "_Melee Weapon Attack: _+2 to hit, reach 5 ft., one target. _Hit: _3 (1d6) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6"
+           :to-hit 2})
+        (provide-feature
+          {:id :creatures-priest/priests
+           :name "Priests"
+           :desc "bring the teachings of their gods to the common folk. They are the spiritual leaders of temples and shrines and often hold positions of influence in their communities. Evil priests might work openly under a tyrant, or they might be the leaders of religious sects hidden in the shadows of good society, overseeing depraved rites."}))}
+  {:id :creatures/scout
+   :name "Scout"
+   :ac 13
+   :challenge 0.5
+   :hit-points "3d8 + 3"
+   :abilities {:str 11 :dex 14 :con 12 :int 11 :wis 13 :cha 11}
+   :senses "passive Perception 15"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-scout/keen-hearing-and-sight
+           :name "Keen Hearing and Sight"
+           :desc "The scout has advantage on Wisdom (Perception) checks that rely on hearing or sight."})
+        (provide-attr
+          [:attacks :creatures-scout/multiattack]
+          {:id :creatures-scout/multiattack
+           :name "Multiattack"
+           :desc "The scout makes two melee attacks or two ranged attacks."})
+        (provide-attr
+          [:attacks :creatures-scout/shortsword]
+          {:id :creatures-scout/shortsword
+           :name "Shortsword"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-scout/longbow]
+          {:id :creatures-scout/longbow
+           :name "Longbow"
+           :desc "_Ranged Weapon Attack: _+4 to hit, ranged 150/600 ft., one target. _Hit: _6 (1d8 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d8+2"
+           :to-hit 4})
+        (provide-feature
+          {:id :creatures-scout/scouts
+           :name "Scouts"
+           :desc "are skilled hunters and trackers who offer their services for a fee. Most hunt wild game, but a few work as bounty hunters, serve as guides, or provide military reconnaissance."}))}
+  {:id :creatures/spy
+   :name "Spy"
+   :ac 12
+   :challenge 1
+   :hit-points "6d8"
+   :abilities {:str 10 :dex 15 :con 10 :int 12 :wis 14 :cha 16}
+   :senses "passive Perception 16"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-spy/cunning-action
+           :name "Cunning Action"
+           :desc "On each of its turns, the spy can use a bonus action to take the Dash, Disengage, or Hide action."})
+        (provide-feature
+          {:id :creatures-spy/sneak-attack
+           :name "Sneak Attack (1/Turn)"
+           :desc "The spy deals an extra 7 (2d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 feet of an ally of the spy that isn’t incapacitated and the spy doesn’t have disadvantage on the attack roll."})
+        (provide-attr
+          [:attacks :creatures-spy/multiattack]
+          {:id :creatures-spy/multiattack
+           :name "Multiattack"
+           :desc "The spy makes two melee attacks."})
+        (provide-attr
+          [:attacks :creatures-spy/shortsword]
+          {:id :creatures-spy/shortsword
+           :name "Shortsword"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-spy/hand-crossbow]
+          {:id :creatures-spy/hand-crossbow
+           :name "Hand Crossbow"
+           :desc "_Ranged Weapon Attack: _+4 to hit, range 30/120 ft., one target. _Hit: _5 (1d6 + 2) piercing damage."
+           :damage :piercing
+           :dice "1d6+2"
+           :to-hit 4}))}
+  {:id :creatures/thug
+   :name "Thug"
+   :ac 11
+   :challenge 0.5
+   :hit-points "5d8 + 10"
+   :abilities {:str 15 :dex 11 :con 14 :int 10 :wis 10 :cha 11}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-thug/pack-tactics
+           :name "Pack Tactics"
+           :desc "The thug has advantage on an attack roll against a creature if at least one of the thug’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-thug/multiattack]
+          {:id :creatures-thug/multiattack
+           :name "Multiattack"
+           :desc "The thug makes two melee attacks."})
+        (provide-attr
+          [:attacks :creatures-thug/mace]
+          {:id :creatures-thug/mace
+           :name "Mace"
+           :desc "_Melee Weapon Attack: _+4 to hit, reach 5 ft., one creature. _Hit: _5 (1d6 + 2) bludgeoning damage."
+           :damage :bludgeoning
+           :dice "1d6+2"
+           :to-hit 4})
+        (provide-attr
+          [:attacks :creatures-thug/heavy-crossbow]
+          {:id :creatures-thug/heavy-crossbow
+           :name "Heavy Crossbow"
+           :desc "_Ranged Weapon Attack: _+2 to hit, range 100/400 ft., one target. _Hit: _5 (1d10) piercing damage."
+           :damage :piercing
+           :dice "1d10"
+           :to-hit 2})
+        (provide-feature
+          {:id :creatures-thug/thugs
+           :name "Thugs"
+           :desc "are ruthless enforcers skilled at intimidation and violence. They work for money and have few scruples."}))}
+  {:id :creatures/tribal-warrior
+   :name "Tribal Warrior"
+   :ac 12
+   :challenge 0.125
+   :hit-points "2d8 + 2"
+   :abilities {:str 13 :dex 11 :con 12 :int 8 :wis 11 :cha 8}
+   :senses "passive Perception 10"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-feature
+          {:id :creatures-tribal-warrior/pack-tactics
+           :name "Pack Tactics"
+           :desc "The warrior has advantage on an attack roll against a creature if at least one of the warrior’s allies is within 5 feet of the creature and the ally isn’t incapacitated."})
+        (provide-attr
+          [:attacks :creatures-tribal-warrior/spear]
+          {:id :creatures-tribal-warrior/spear
+           :name "Spear"
+           :desc "_Melee or Ranged Weapon Attack: _+3 to hit, reach 5 ft. or range 20/60 ft., one target. _Hit: _4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack."
+           :damage :piercing
+           :dice "1d6+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-tribal-warrior/tribal-warriors
+           :name "Tribal warriors"
+           :desc "live beyond civilization, most often subsisting on fishing and hunting. Each tribe acts in accordance with the wishes of its chief, who is the greatest or oldest warrior of the tribe or a tribe member blessed by the gods."}))}
+  {:id :creatures/veteran
+   :name "Veteran"
+   :ac 17
+   :challenge 3
+   :hit-points "9d8 + 18"
+   :abilities {:str 16 :dex 13 :con 14 :int 10 :wis 11 :cha 10}
+   :senses "passive Perception 12"
+   :size :medium
+   :type :humanoid
+   :speed "30 ft."
+   :! (on-state
+        (provide-attr
+          [:attacks :creatures-veteran/multiattack]
+          {:id :creatures-veteran/multiattack
+           :name "Multiattack"
+           :desc "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."})
+        (provide-attr
+          [:attacks :creatures-veteran/longsword]
+          {:id :creatures-veteran/longsword
+           :name "Longsword"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands."
+           :damage :slashing
+           :dice "1d8+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-veteran/shortsword]
+          {:id :creatures-veteran/shortsword
+           :name "Shortsword"
+           :desc "_Melee Weapon Attack: _+5 to hit, reach 5 ft., one target. _Hit: _6 (1d6 + 3) piercing damage."
+           :damage :piercing
+           :dice "1d6+3"
+           :to-hit 5})
+        (provide-attr
+          [:attacks :creatures-veteran/heavy-crossbow]
+          {:id :creatures-veteran/heavy-crossbow
+           :name "Heavy Crossbow"
+           :desc "_Ranged Weapon Attack: _+3 to hit, range 100/400 ft., one target. _Hit: _6 (1d10 + 1) piercing damage."
+           :damage :piercing
+           :dice "1d10+1"
+           :to-hit 3})
+        (provide-feature
+          {:id :creatures-veteran/veterans
+           :name "Veterans"
+           :desc "are professional fighters that take up arms for pay or to protect something they believe in or value. Their ranks include soldiers retired from long service and warriors who never served anyone but themselves."}))})

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -17,7 +17,7 @@
                 [wish-engine "0.1.0-SNAPSHOT"]
 
                 ; style and input:
-                [net.dhleong/spade "1.0.4"]
+                [net.dhleong/spade "1.1.0"]
                 [reagent-forms "0.5.44"]
                 [re-pressed "0.3.1"]
                 [net.dhleong/santiago "0.1.0-SNAPSHOT"]

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -20,6 +20,7 @@
                 [net.dhleong/spade "1.0.4"]
                 [reagent-forms "0.5.44"]
                 [re-pressed "0.3.1"]
+                [net.dhleong/santiago "0.1.0-SNAPSHOT"]
 
                 ; ::inject/sub cofx (for subscriptions in event handlers)
                 [re-frame-utils "0.1.0"]

--- a/src/cljs/wish/events.cljs
+++ b/src/cljs/wish/events.cljs
@@ -942,6 +942,13 @@
           (assoc-in allies (cons index set-path) new-value)
           allies)))))
 
+(reg-event-db
+  :allies/select-category
+  [trim-v]
+  (fn-traced [db [category-id]]
+    (assoc db :allies/selected-category category-id)))
+
+
 ; ======= Save-state handling ==============================
 
 (reg-event-db

--- a/src/cljs/wish/sheets/dnd5e/overlays/allies.cljs
+++ b/src/cljs/wish/sheets/dnd5e/overlays/allies.cljs
@@ -40,7 +40,7 @@
    ])
 
 (defattrs ally-category-attrs []
-  [:.desc {:font-size :90%
+  [:.desc {:font-size :80%
            :padding "4px"}])
 
 (defn- ally-category-selector []

--- a/src/cljs/wish/sheets/dnd5e/overlays/allies.cljs
+++ b/src/cljs/wish/sheets/dnd5e/overlays/allies.cljs
@@ -1,10 +1,11 @@
 (ns wish.sheets.dnd5e.overlays.allies
   "Ally management overlay"
-  (:require [spade.core :refer [defattrs]]
+  (:require [santiago.select :refer [select]]
+            [spade.core :refer [defattrs]]
             [wish.inventory :refer [instantiate-id]]
             [wish.sheets.dnd5e.overlays.style :as styles]
             [wish.sheets.dnd5e.subs.allies :as allies]
-            [wish.util :refer [click>evt click>evts <sub]]
+            [wish.util :refer [click>evt click>evts <sub >evt]]
             [wish.views.widgets :as widgets :refer-macros [icon]]
             [wish.views.widgets.virtual-list :refer [virtual-list]]))
 
@@ -38,6 +39,31 @@
     "Summon"]
    ])
 
+(defattrs ally-category-attrs []
+  [:.desc {:font-size :90%
+           :padding "4px"}])
+
+(defn- ally-category-selector []
+  (when-let [categories (seq (<sub [:allies/categories]))]
+    (let [selected (<sub [:allies/selected-category])]
+      [:div (ally-category-attrs)
+       "Category Filter:"
+
+       [select {:on-change (fn [new-id]
+                             (>evt [:allies/select-category new-id]))
+                :value (:id selected)}
+        [:option {:key nil}
+         "(None)"]
+
+        (for [{:keys [id] :as category} categories]
+          [:option {:key id}
+           (:name category)])]
+
+       (when selected
+         [:div.desc (:desc selected)])
+       ])
+    ))
+
 (defn overlay []
   [:div (styles/item-adder-overlay)
    [:h4 "Allies"]
@@ -46,6 +72,8 @@
     {:filter-key :5e/allies-filter
      :placeholder "Search for an ally..."
      :auto-focus true}]
+
+   [ally-category-selector]
 
    [:div.item-browser.scrollable
     [virtual-list

--- a/src/cljs/wish/sheets/dnd5e/subs/allies.cljs
+++ b/src/cljs/wish/sheets/dnd5e/subs/allies.cljs
@@ -71,11 +71,16 @@
 (reg-id-sub
   ::all-inflated
   :<- [:composite-sheet-engine-state]
+  :<- [:allies/selected-category]
   :<- [:allies/preferred-map]
-  (fn [[source preferred] _]
+  (fn [[source category preferred] _]
     (->> (engine/inflate-list source :all-creatures)
-         (map (fn [{id :id :as ally}]
-                (assoc ally :preferred? (preferred id)))))))
+         (transduce
+           (comp
+             (filter (:filter category identity))
+             (map (fn [{id :id :as ally}]
+                    (assoc ally :preferred? (preferred id)))))
+           conj []))))
 
 (reg-id-sub
   ::all-sorted

--- a/src/cljs/wish/subs.cljs
+++ b/src/cljs/wish/subs.cljs
@@ -846,6 +846,25 @@
                       (select-keys info [:id :instance-id]))))
          first)))
 
+(reg-id-sub
+  :allies/categories
+  :<- [:composite-sheet-engine-state]
+  (fn [sources _]
+    (engine/inflate-list sources :wish/ally-categories)))
+
+(reg-sub
+  :allies/selected-category-id
+  (fn [db _]
+    (:allies/selected-category db)))
+
+(reg-sub
+  :allies/selected-category
+  :<- [:composite-sheet-engine-state]
+  :<- [:allies/selected-category-id]
+  (fn [[sources category-id] _]
+    (when category-id
+      (first (engine/inflate-list sources [category-id])))))
+
 
 ; ======= character builder-related ========================
 


### PR DESCRIPTION
This gives us a powerful way for classes to declare that the user can
pick from certain sets of allies in response to a feature, such as
Druid's Wild Shape ability.